### PR TITLE
Stop hardcoding supported characters

### DIFF
--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -106,58 +106,32 @@ impl<'e> Editor<'e> {
     }
 
     fn handle_system_event(&mut self, k: Option<Key>) -> EventStatus {
+        use super::keyboard;
+
         let key = match k {
             Some(k) => k,
             None => return EventStatus::NotHandled
         };
 
         match key {
-            Key::Up        => { self.view.move_cursor(Direction::Up); }
-            Key::Down      => { self.view.move_cursor(Direction::Down); }
-            Key::Left      => { self.view.move_cursor(Direction::Left); }
-            Key::Right     => { self.view.move_cursor(Direction::Right); }
-            Key::Enter     => { self.view.insert_line(); }
+            keyboard::UP        => { self.view.move_cursor(Direction::Up); }
+            keyboard::DOWN      => { self.view.move_cursor(Direction::Down); }
+            keyboard::LEFT      => { self.view.move_cursor(Direction::Left); }
+            keyboard::RIGHT     => { self.view.move_cursor(Direction::Right); }
+            keyboard::ENTER     => { self.view.insert_line(); }
 
             // Tab inserts 4 spaces, rather than a \t
-            Key::Tab       => { self.view.insert_tab(); }
+            keyboard::TAB       => { self.view.insert_tab(); }
 
-            Key::Backspace => { self.view.delete_char(Direction::Left); }
-            Key::Delete    => { self.view.delete_char(Direction::Right); }
-            Key::CtrlS     => { self.save_active_buffer(); }
-            Key::CtrlQ     => { return EventStatus::Handled(Response::Quit) }
-            Key::CtrlR     => { self.view.resize(); }
+            keyboard::BACKSPACE => { self.view.delete_char(Direction::Left); }
+            keyboard::DELETE    => { self.view.delete_char(Direction::Right); }
+            keyboard::CTRL_S     => { self.save_active_buffer(); }
+            keyboard::CTRL_Q     => { return EventStatus::Handled(Response::Quit) }
+            keyboard::CTRL_R     => { self.view.resize(); }
 
             // TODO(greg): move these keys to event handlers of each mode
             // This block is for matching keys which will insert a char to the buffer
-            Key::Exclaim   |  Key::Hash |
-            Key::Dollar    | Key::Percent |
-            Key::Ampersand | Key::Quote |
-            Key::LeftParen | Key::RightParen |
-            Key::Asterisk  | Key::Plus |
-            Key::Comma     | Key::Minus |
-            Key::Period    | Key::Slash |
-            Key::D0 | Key::D1 | Key::D2 |
-            Key::D3 | Key::D4 | Key::D5 |
-            Key::D6 | Key::D7 | Key::D8 |
-            Key::D9 | Key::Colon |
-            Key::Semicolon | Key::Less |
-            Key::Equals    | Key::Greater |
-            Key::Question  | Key::At |
-            Key::LeftBracket  | Key::Backslash |
-            Key::RightBracket | Key::Caret |
-            Key::Underscore   | Key::Backquote |
-            Key::A | Key::B | Key::C | Key::D |
-            Key::E | Key::F | Key::G | Key::H |
-            Key::I | Key::J | Key::K | Key::L |
-            Key::M | Key::N | Key::O | Key::P |
-            Key::Q | Key::R | Key::S | Key::T |
-            Key::U | Key::V | Key::W | Key::X |
-            Key::Y | Key::Z | Key::LeftBrace |
-            Key::Pipe       | Key::RightBrace |
-            Key::Tilde      | Key::Space => { self.view.insert_char(key.get_char().unwrap()) }
-
-            // default
-            _              => { return EventStatus::NotHandled }
+            _ => { self.view.insert_char(key.get_char().unwrap()) }
         }
         // event is handled and we want to keep the editor running
         EventStatus::Handled(Response::Continue)

--- a/src/iota/keyboard.rs
+++ b/src/iota/keyboard.rs
@@ -1,94 +1,28 @@
 use std::num::FromPrimitive;
 use std::char;
 
-pub enum Key {
-    Unknown      = 0,
-    Tab          = 9,
-    Enter        = 13,
-    CtrlQ        = 17,
-    CtrlR        = 18,
-    CtrlS        = 19,
-    Esc          = 27,
-    Space        = 32,
-    Exclaim      = 33,
-    Hash         = 35,
-    Dollar       = 36,
-    Percent      = 37,
-    Ampersand    = 38,
-    Quote        = 39,
-    LeftParen    = 40,
-    RightParen   = 41,
-    Asterisk     = 42,
-    Plus         = 43,
-    Comma        = 44,
-    Minus        = 45,
-    Period       = 46,
-    Slash        = 47,
-    D0           = 48,
-    D1           = 49,
-    D2           = 50,
-    D3           = 51,
-    D4           = 52,
-    D5           = 53,
-    D6           = 54,
-    D7           = 55,
-    D8           = 56,
-    D9           = 57,
-    Colon        = 58,
-    Semicolon    = 59,
-    Less         = 60,
-    Equals       = 61,
-    Greater      = 62,
-    Question     = 63,
-    At           = 64,
-    LeftBracket  = 91,
-    Backslash    = 92,
-    RightBracket = 93,
-    Caret        = 94,
-    Underscore   = 95,
-    Backquote    = 96,
-    A            = 97,
-    B            = 98,
-    C            = 99,
-    D            = 100,
-    E            = 101,
-    F            = 102,
-    G            = 103,
-    H            = 104,
-    I            = 105,
-    J            = 106,
-    K            = 107,
-    L            = 108,
-    M            = 109,
-    N            = 110,
-    O            = 111,
-    P            = 112,
-    Q            = 113,
-    R            = 114,
-    S            = 115,
-    T            = 116,
-    U            = 117,
-    V            = 118,
-    W            = 119,
-    X            = 120,
-    Y            = 121,
-    Z            = 122,
-    LeftBrace    = 123,
-    Pipe         = 124,
-    RightBrace   = 125,
-    Tilde        = 126,
-    Backspace    = 127,
-    Right        = 65514,
-    Left         = 65515,
-    Down         = 65516,
-    Up           = 65517,
-    Delete       = 65522,
+pub struct Key {
+    code: u64
 }
+
+pub const TAB: Key       = Key { code: 9 };
+pub const ENTER: Key     = Key { code: 13 };
+pub const CTRL_Q: Key     = Key { code: 17 };
+pub const CTRL_R: Key     = Key { code: 18 };
+pub const CTRL_S: Key     = Key { code: 19 };
+#[allow(dead_code)]
+pub const ESC: Key       = Key { code: 27 };
+pub const BACKSPACE: Key = Key { code: 127 };
+pub const RIGHT: Key     = Key { code: 65514 };
+pub const LEFT: Key      = Key { code: 65515 };
+pub const DOWN: Key      = Key { code: 65516 };
+pub const UP: Key        = Key { code: 65517 };
+pub const DELETE: Key    = Key { code: 65522 };
 
 impl Key {
     #[inline(always)]
     pub fn code(&self) -> u32 {
-        *self as u32
+        self.code as u32
     }
 
     pub fn get_char(&self) -> Option<char> {
@@ -98,90 +32,7 @@ impl Key {
 
 impl FromPrimitive for Key {
     fn from_u64(n: u64) -> Option<Key> {
-        match n {
-            0     => Some(Key::Unknown),
-            9     => Some(Key::Tab),
-            13    => Some(Key::Enter),
-            17    => Some(Key::CtrlQ),
-            18    => Some(Key::CtrlR),
-            19    => Some(Key::CtrlS),
-            27    => Some(Key::Esc),
-            32    => Some(Key::Space),
-            33    => Some(Key::Exclaim),
-            35    => Some(Key::Hash),
-            36    => Some(Key::Dollar),
-            37    => Some(Key::Percent),
-            38    => Some(Key::Ampersand),
-            39    => Some(Key::Quote),
-            40    => Some(Key::LeftParen),
-            41    => Some(Key::RightParen),
-            42    => Some(Key::Asterisk),
-            43    => Some(Key::Plus),
-            44    => Some(Key::Comma),
-            45    => Some(Key::Minus),
-            46    => Some(Key::Period),
-            47    => Some(Key::Slash),
-            48    => Some(Key::D0),
-            49    => Some(Key::D1),
-            50    => Some(Key::D2),
-            51    => Some(Key::D3),
-            52    => Some(Key::D4),
-            53    => Some(Key::D5),
-            54    => Some(Key::D6),
-            55    => Some(Key::D7),
-            56    => Some(Key::D8),
-            57    => Some(Key::D9),
-            58    => Some(Key::Colon),
-            59    => Some(Key::Semicolon),
-            60    => Some(Key::Less),
-            61    => Some(Key::Equals),
-            62    => Some(Key::Greater),
-            63    => Some(Key::Question),
-            64    => Some(Key::At),
-            91    => Some(Key::LeftBracket),
-            92    => Some(Key::Backslash),
-            93    => Some(Key::RightBracket),
-            94    => Some(Key::Caret),
-            95    => Some(Key::Underscore),
-            96    => Some(Key::Backquote),
-            97    => Some(Key::A),
-            98    => Some(Key::B),
-            99    => Some(Key::C),
-            100   => Some(Key::D),
-            101   => Some(Key::E),
-            102   => Some(Key::F),
-            103   => Some(Key::G),
-            104   => Some(Key::H),
-            105   => Some(Key::I),
-            106   => Some(Key::J),
-            107   => Some(Key::K),
-            108   => Some(Key::L),
-            109   => Some(Key::M),
-            110   => Some(Key::N),
-            111   => Some(Key::O),
-            112   => Some(Key::P),
-            113   => Some(Key::Q),
-            114   => Some(Key::R),
-            115   => Some(Key::S),
-            116   => Some(Key::T),
-            117   => Some(Key::U),
-            118   => Some(Key::V),
-            119   => Some(Key::W),
-            120   => Some(Key::X),
-            121   => Some(Key::Y),
-            122   => Some(Key::Z),
-            123   => Some(Key::LeftBrace),
-            124   => Some(Key::Pipe),
-            125   => Some(Key::RightBrace),
-            126   => Some(Key::Tilde),
-            127   => Some(Key::Backspace),
-            65514 => Some(Key::Right),
-            65515 => Some(Key::Left),
-            65516 => Some(Key::Down),
-            65517 => Some(Key::Up),
-            65522 => Some(Key::Delete),
-            _     => None
-        }
+        Some(Key { code: n })
     }
 
     #[inline(always)]


### PR DESCRIPTION
This isn't exactly the greatest interface for characters, but at least it now works with characters that weren't hardcoded in the program (_e.g._ capital letters).

This fixes #17.
