### PR TITLE
Use Path instead of String to store file paths.

### DIFF
--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -50,9 +50,9 @@ impl<'e> Editor<'e> {
 
     pub fn save_active_buffer(&mut self) {
         let lines = &self.view.buffer.lines;
-        let path = Path::new(&self.view.buffer.file_path);
+        let path = self.view.buffer.file_path.as_ref().unwrap();
 
-        let mut file = match File::open_mode(&path, FileMode::Open, FileAccess::Write) {
+        let mut file = match File::open_mode(path, FileMode::Open, FileAccess::Write) {
             Ok(f) => f,
             Err(e) => panic!("file error: {}", e),
         };

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -31,7 +31,7 @@ impl<'v> View<'v> {
         let buffer = match source {
             Input::Filename(path) => {
                 match path {
-                    Some(s) => Buffer::new_from_file(&Path::new(s)),
+                    Some(s) => Buffer::new_from_file(Path::new(s)),
                     None    => Buffer::new_empty(),
                 }
             },


### PR DESCRIPTION
Also fixes a race condition when opening files by checking
for the files existence by trying to open the file, instead of
checking beforehand, which can lead to a race.

Credit to @pythonesque for discovering the race condition.
