### PR TITLE
Don't redraw cells that haven't changed

### DIFF
--- a/src/iota/uibuf.rs
+++ b/src/iota/uibuf.rs
@@ -18,17 +18,21 @@ impl UIBuffer {
         }
     }
 
-    pub fn draw_range(&self, start: uint, stop: uint) {
-        let rows = self.rows.slice(start, stop);
-        for row in rows.iter() {
-            for cell in row.iter() {
-                rustbox::print_char(cell.x, cell.y, rustbox::Style::Normal, cell.fg, cell.bg, cell.ch);
+    pub fn draw_range(&mut self, start: uint, stop: uint) {
+        let mut rows = self.rows.slice_mut(start, stop);
+        for row in rows.iter_mut() {
+            for cell in row.iter_mut() {
+                if cell.dirty {
+                    rustbox::print_char(cell.x, cell.y, rustbox::Style::Normal, cell.fg, cell.bg, cell.ch);
+                    cell.dirty = false;
+                }
             }
         }
     }
 
-    pub fn draw_everything(&self) {
-        self.draw_range(0, self.height);
+    pub fn draw_everything(&mut self) {
+        let height = self.height;
+        self.draw_range(0, height);
     }
 
     pub fn get_width(&self) -> uint {
@@ -39,22 +43,25 @@ impl UIBuffer {
         self.height
     }
 
-    /// Recreated the entire grid, will cells containing `ch`.
+    /// Set all cells to `ch`.
     pub fn fill(&mut self, ch: char) {
-        self.rows = Cell::create_grid(self.width, self.height, ch);
+        for row in self.rows.iter_mut() {
+            for cell in row.iter_mut() {
+                cell.set_char(ch);
+            }
+        }
     }
 
     /// Update the `ch` attribute of an individual cell
     pub fn update_cell_content(&mut self, cell_num: uint, row_num: uint, ch: char) {
-        self.rows[row_num][cell_num].ch = ch
+        self.rows[row_num][cell_num].set_char(ch);
     }
 
     /// Update the `ch`, `fg`, and `bg` attributes of an indivudual cell
     pub fn update_cell(&mut self, cell_num: uint, row_num: uint, ch: char, fg: rustbox::Color, bg: rustbox::Color) {
         let cell = self.get_cell_mut(cell_num, row_num);
-        cell.ch = ch;
-        cell.fg = fg;
-        cell.bg = bg;
+        cell.set_char(ch);
+        cell.set_attrs(fg, bg);
     }
 
     pub fn get_cell_mut(&mut self, cell_num: uint, row_num: uint) -> &mut Cell {
@@ -69,6 +76,7 @@ pub struct Cell {
     pub ch: char,
     pub x: uint,
     pub y: uint,
+    pub dirty: bool
 }
 
 
@@ -80,7 +88,22 @@ impl Cell {
             ch: ' ',
             x: 0,
             y: 0,
+            dirty: true
         }
+    }
+
+    pub fn set_char(&mut self, ch: char) {
+        if ch != self.ch {
+            self.ch = ch;
+            self.dirty = true;
+        }
+    }
+
+    pub fn set_attrs(&mut self, fg: rustbox::Color, bg: rustbox::Color) {
+        // rustbox::Color should probably `impl PartialEq`
+        self.dirty = true;
+        self.fg = fg;
+        self.bg = bg;
     }
 
     pub fn create_grid(width: uint, height: uint, ch: char) -> Vec<Vec<Cell>> {


### PR DESCRIPTION
Partial fix for #4.

`rustbox::Color` doesn't seem to implement `PartialEq`, which complicates testing for changes to the foreground/background attributes of a cell.
