### PR TITLE
Preserve the cursor’s offset when moving to a shorter line

### DIFF
--- a/src/iota/cursor.rs
+++ b/src/iota/cursor.rs
@@ -1,4 +1,5 @@
 use buffer::Line;
+use std::cmp;
 
 #[deriving(Copy, Show)]
 pub enum Direction {
@@ -33,22 +34,14 @@ pub struct Cursor<'c> {
 impl<'c> Cursor<'c> {
     /// Create a new cursor instance
     pub fn new(line: &'c mut Line, offset: uint) -> Cursor<'c> {
-        let mut cursor = Cursor {
+        Cursor {
             offset: offset,
             line: line,
-        };
-
-        // check that the current offset is longer than the length of the line
-        let offset = cursor.get_offset();
-        let line_length = cursor.get_line().len();
-        if offset > line_length {
-            cursor.set_offset(line_length);
         }
-        cursor
     }
 
     pub fn get_position(&self) -> (uint, uint) {
-        (self.offset, self.get_linenum())
+        (self.get_offset(), self.get_linenum())
     }
 
     pub fn get_linenum(&self) -> uint {
@@ -56,6 +49,10 @@ impl<'c> Cursor<'c> {
     }
 
     pub fn get_offset(&self) -> uint {
+        cmp::min(self.line.len(), self.offset)
+    }
+
+    pub fn get_actual_offset(&self) -> uint {
         self.offset
     }
 
@@ -73,7 +70,7 @@ impl<'c> Cursor<'c> {
     /// byte long. This function calculates the width of the current codepoint and increments the
     /// offset by that width, ensuring that the cursor will always be on a character boundary.
     pub fn inc_offset(&mut self) {
-        let range = self.get_line().data.char_range_at(self.offset);
+        let range = self.get_line().data.char_range_at(self.get_offset());
         self.set_offset(range.next);
     }
 
@@ -81,7 +78,7 @@ impl<'c> Cursor<'c> {
     ///
     /// See `inc_offset` for why this method is needed.
     pub fn dec_offset(&mut self) {
-        let range = self.get_line().data.char_range_at_reverse(self.offset);
+        let range = self.get_line().data.char_range_at_reverse(self.get_offset());
         self.set_offset(range.next);
     }
 
@@ -99,7 +96,7 @@ impl<'c> Cursor<'c> {
 
     pub fn delete_backward_char(&mut self) {
         let offset = self.get_offset();
-        let range = self.get_line().data.char_range_at_reverse(self.offset);
+        let range = self.get_line().data.char_range_at_reverse(self.get_offset());
         let back = self.offset - range.next;
         self.dec_offset();
         self.get_line_mut().data.remove(offset-back);
@@ -208,7 +205,8 @@ mod tests {
         let ref mut line = Line::new(data_from_str("test"), 1);
         let cursor = Cursor::new(line, 10);
 
-        assert_eq!(cursor.offset, 4);
+        assert_eq!(cursor.offset, 10);
+        assert_eq!(cursor.get_offset(), 4);
     }
 
     #[test]

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -31,7 +31,7 @@ impl<'a> Drop for CursorGuard<'a> {
     fn drop(&mut self) {
         // Update line number and offset
         *self.linenum = self.cursor.get_linenum();
-        *self.offset = self.cursor.get_offset();
+        *self.offset = self.cursor.get_actual_offset();
     }
 }
 
@@ -162,8 +162,7 @@ impl<'v> View<'v> {
     }
 
     pub fn move_cursor_to_line_end(&mut self) {
-        let eol_offset = self.cursor().get_line().len();
-        self.cursor().set_offset(eol_offset);
+        self.cursor().set_offset(::std::uint::MAX);
     }
 
     pub fn move_cursor_to_line_start(&mut self) {


### PR DESCRIPTION
As an example of what this changes, consider the following file, where the block represents the cursor’s current position:

```
     a long line█
     short
Old: anoth█er long line
New: another lon█g line
```

Moving the cursor down twice used to place the cursor five characters (the length of `short`) along the line. Now, it preserves the original offset from the first line, which is the behaviour present in most editors. Furthermore, moving to the end of a line with a keyboard command (Ctrl-E) will place the cursor at the end of all lines even after switching to a longer one.
