### PR TITLE
Fix crash when adding a character at end of line

### DIFF
--- a/src/iota/cursor.rs
+++ b/src/iota/cursor.rs
@@ -110,7 +110,7 @@ impl<'c> Cursor<'c> {
     pub fn insert_char(&mut self, ch: char) {
         let offset = self.get_offset();
         self.get_line_mut().data.insert(offset, ch);
-        self.inc_offset();
+        self.move_right();
     }
 
     pub fn move_right(&mut self) {


### PR DESCRIPTION
After using CTRL + E to go to the end of the line, inserting a character currently crashes iota.  This commit fixes that by delegating to `move_right`, which correctly handles the boundary condition.
