### PR TITLE
Adding undo and redo.

### DIFF
--- a/src/iota/keyboard.rs
+++ b/src/iota/keyboard.rs
@@ -33,6 +33,8 @@ impl Key {
             18    => Some(Key::Ctrl('r')),
             19    => Some(Key::Ctrl('s')),
             24    => Some(Key::Ctrl('x')),
+            25    => Some(Key::Ctrl('y')),
+            26    => Some(Key::Ctrl('z')),
             27    => Some(Key::Esc),
             32    => Some(Key::Char(' ')),
             127   => Some(Key::Backspace),

--- a/src/iota/keymap.rs
+++ b/src/iota/keymap.rs
@@ -115,7 +115,7 @@ impl KeyMap {
             _ => self.state
         }
     }
-    
+
     /// Insert or overwrite a key-sequence binding
     pub fn bind_keys(&mut self, keys: &[Key], command: Command) {
         self.root.bind_keys(keys.as_slice(), command);
@@ -157,6 +157,10 @@ impl KeyMap {
         keymap.bind_key(Key::Ctrl('h'), Command::Delete(Direction::Left));
         keymap.bind_key(Key::Delete, Command::Delete(Direction::Right));
         keymap.bind_key(Key::Ctrl('d'), Command::Delete(Direction::Right));
+
+        // History
+        keymap.bind_key(Key::Ctrl('y'), Command::Redo);
+        keymap.bind_key(Key::Ctrl('z'), Command::Undo);
 
         return keymap
     }

--- a/src/iota/lib.rs
+++ b/src/iota/lib.rs
@@ -15,6 +15,7 @@ mod keyboard;
 mod keymap;
 mod view;
 mod uibuf;
+mod log;
 
 #[deriving(Copy)]
 pub enum Response {

--- a/src/iota/log.rs
+++ b/src/iota/log.rs
@@ -1,0 +1,161 @@
+/// Primitive command log, currently used for undo / redo.
+/// This is a deliberately unoptimized representation, for simplicity.  It is by no means final.
+
+use buffer::Line;
+use cursor::CursorData;
+
+use std::mem;
+
+/// Represents a modification of data (currently by line).
+pub enum Change {
+    /// Line insertion.
+    ///
+    /// Associated Line holds the new contents of the inserted line.
+    Insert(Line),
+    /// Line update.
+    ///
+    /// First entry holds the old contents of the Line, second holds the new contents.
+    Update(Line, String),
+    /// Line deletion.
+    ///
+    /// Associated Line holds the old contents of the line.
+    Delete(Line),
+}
+
+impl Change {
+    /// Reverses a change, consuming it in the process
+    pub fn reverse(self) -> Change {
+        match self {
+            Change::Insert(line) => Change::Delete(line),
+            Change::Update(old, new) =>
+                Change::Update(Line { linenum: old.linenum, data: new }, old.data),
+            Change::Delete(line) => Change::Insert(line),
+        }
+    }
+}
+
+/// Log entry
+/// Entries may only be played linearly--they don't make sense out of order.
+pub struct LogEntry {
+    /// The initial cursor position associated with this log entry.
+    ///
+    /// The OLD cursor position.
+    pub cursor_start: CursorData,
+    /// The NEW cursor position.
+    pub cursor_end: CursorData,
+    /// The changes associated with this log entry, in order of occurence (an undo will replay
+    /// their inverses, backwards).
+    pub changes: Vec<Change>,
+}
+
+impl LogEntry {
+    /// Reverse a log entry, consuming it in the process.
+    pub fn reverse(mut self) -> LogEntry {
+        self.changes.reverse();
+        LogEntry {
+            cursor_start: self.cursor_end,
+            cursor_end: self.cursor_start,
+            changes: self.changes.map_in_place( |change| change.reverse() ),
+        }
+    }
+}
+
+/// A set of `Change`s that should be treated atomically.
+///
+/// This transaction always has an associated entry log.  When the transaction is dropped, the
+/// entries are committed.
+pub struct Transaction<'a> {
+    /// Currently, only one transaction may be open at a time.
+    entries: &'a mut LogEntries,
+    /// The LogEntry under construction by the transaction.  Every data modification should be
+    /// recorded with the open Transaction.
+    entry: LogEntry,
+}
+
+impl<'a> Transaction<'a> {
+    /// Log a change with this transaction.
+    ///
+    /// The logging should occur after the change has been executed.  This may eventually allow
+    /// rollback in case of failure.
+    pub fn log(&mut self, change: Change, cursor_data: CursorData) {
+        self.entry.changes.push(change);
+        self.entry.cursor_end = cursor_data;
+    }
+}
+
+#[unsafe_destructor]
+impl<'a> Drop for Transaction<'a> {
+    fn drop(&mut self) {
+        // Check to see if there were any changes, and if not return early.
+        if self.entry.changes.is_empty() { return }
+        // Create the new log entry
+        let entry = LogEntry {
+            changes: mem::replace(&mut self.entry.changes, Vec::new()),
+            .. self.entry
+        };
+        // Commit the transaction.
+        self.entries.undo.push(entry);
+        // Clear the redo entries now that the transaction has been committed.
+        self.entries.redo.clear();
+    }
+}
+
+/// Log entries structure.  Just two stacks.
+pub struct LogEntries {
+    /// Undo log entries--LIFO stack.
+    undo: Vec<LogEntry>,
+    /// Redo log entries--LIFO stack.  Cleared after a new change (other than an undo or redo)
+    /// is committed.
+    redo: Vec<LogEntry>,
+}
+
+impl LogEntries {
+    /// Set up log entries.  They are initially empty.
+    pub fn new() -> LogEntries {
+        LogEntries {
+            undo: Vec::new(),
+            redo: Vec::new(),
+        }
+    }
+
+    /// Start a new transaction.
+    ///
+    /// This returns a RAII guard that can be used to record edits during the transaction.
+    pub fn start<'a, 'b>(&'a mut self, cursor_data: CursorData) -> Transaction<'a> {
+        Transaction {
+            entries: self,
+            entry: LogEntry {
+                cursor_start: cursor_data,
+                cursor_end: cursor_data,
+                changes: Vec::new(),
+            }
+        }
+    }
+
+    /// This reverses the most recent change on the undo stack, places the new change on the redo
+    /// stack, and then returns a reference to it.  It is the caller's responsibility to actually
+    /// perform the change.
+    pub fn undo<'a>(&'a mut self) -> Option<&'a LogEntry> {
+        match self.undo.pop() {
+            Some(change) => {
+                let last = self.redo.len();
+                self.redo.push(change.reverse());
+                Some(&self.redo[last])
+            },
+            None => None
+        }
+    }
+    /// This reverses the most recent change on the redo stack, places the new change on the undo
+    /// stack, and then returns a reference to it.  It is the caller's responsibility to actually
+    /// perform the change.
+    pub fn redo(&mut self) -> Option<&LogEntry> {
+        match self.redo.pop() {
+            Some(change) => {
+                let last = self.undo.len();
+                self.undo.push(change.reverse());
+                Some(&self.undo[last])
+            },
+            None => None
+        }
+    }
+}

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -1,16 +1,15 @@
 use rustbox::{Color, RustBox};
 
 use buffer::{Line, Buffer};
-use cursor::Direction;
-use cursor::Cursor;
+use cursor::{Cursor, CursorData, Direction};
 use input::Input;
+use log::{LogEntry, Transaction};
 use uibuf::UIBuffer;
 
 use utils;
 
 pub struct CursorGuard<'a> {
-    linenum: &'a mut uint,
-    offset: &'a mut uint,
+    data: &'a mut CursorData,
     cursor: Cursor<'a>,
 }
 
@@ -30,8 +29,10 @@ impl<'a> DerefMut<Cursor<'a>> for CursorGuard<'a> {
 impl<'a> Drop for CursorGuard<'a> {
     fn drop(&mut self) {
         // Update line number and offset
-        *self.linenum = self.cursor.get_linenum();
-        *self.offset = self.cursor.get_actual_offset();
+        *self.data = CursorData {
+            linenum: self.cursor.get_linenum(),
+            offset: self.cursor.get_actual_offset(),
+        }
     }
 }
 
@@ -45,8 +46,7 @@ pub struct View<'v> {
     pub buffer: Buffer,
     // the line number of the topmost `Line` for the View to render
     pub top_line_num: uint,
-    pub linenum: uint,
-    pub offset: uint,
+    pub cursor_data: CursorData,
 
     uibuf: UIBuffer,
     threshold: int,
@@ -77,15 +77,20 @@ impl<'v> View<'v> {
             top_line_num: 0,
             uibuf: uibuf,
             threshold: 5,
-            linenum: 0,
-            offset: 0,
+            cursor_data: CursorData {
+                linenum: 0,
+                offset: 0,
+            }
         }
     }
 
     pub fn cursor<'b>(&'b mut self) -> CursorGuard<'b> {
-        let View {ref mut buffer, ref mut offset, ref mut linenum, .. } = *self;
-        let cursor = Cursor::new(&mut buffer.lines[*linenum], *offset);
-        CursorGuard { cursor: cursor, offset: offset, linenum: linenum }
+        let View {ref mut buffer, ref mut cursor_data, .. } = *self;
+        let cursor = Cursor::new(&mut buffer.lines[cursor_data.linenum], cursor_data.offset);
+        CursorGuard {
+            cursor: cursor,
+            data: cursor_data,
+        }
     }
 
     /// Clear the buffer
@@ -231,9 +236,10 @@ impl<'v> View<'v> {
             vis_acc += ::utils::char_width(c, false, 4, vis_acc).unwrap_or(0);
             vis_acc < vis_width
         }) {}
-        if self.offset == 0 { offset = 0 }
-        self.offset = offset;
-        self.linenum = linenum;
+        self.cursor_data = CursorData {
+            linenum: linenum,
+            offset: if self.cursor_data.offset == 0 { 0 } else { offset },
+        };
     }
 
     fn move_top_line_n_times(&mut self, mut num_times: int) {
@@ -259,13 +265,13 @@ impl<'v> View<'v> {
         }
     }
 
-    pub fn delete_char(&mut self, direction: Direction) {
-        let (offset, line_num) = self.cursor().get_position();
+    pub fn delete_char(&mut self, transaction: &mut Transaction, direction: Direction) {
+        let CursorData { offset, linenum } = self.cursor().get_position();
 
         if offset == 0 && direction.is_left() {
             // Must move the cursor up first so we aren't pointing at dangling memory
             self.move_cursor_up();
-            let offset = self.buffer.join_line_with_previous(offset, line_num);
+            let offset = self.buffer.join_line_with_previous(transaction, offset, linenum);
             self.cursor().set_offset(offset);
             return
         }
@@ -274,34 +280,42 @@ impl<'v> View<'v> {
         if offset == line_len && direction.is_right() {
             // try to join the next line with the current line
             // if there is no next line, nothing will happen
-            self.buffer.join_line_with_previous(offset, line_num+1);
+            self.buffer.join_line_with_previous(transaction, offset, linenum+1);
             return
         }
 
         match direction {
-            Direction::Left  => self.cursor().delete_backward_char(),
-            Direction::Right => self.cursor().delete_forward_char(),
+            Direction::Left  => self.cursor().delete_backward_char(transaction),
+            Direction::Right => self.cursor().delete_forward_char(transaction),
             _                => {}
         }
     }
 
-    pub fn insert_tab(&mut self) {
+    pub fn insert_tab(&mut self, transaction: &mut Transaction) {
         // A tab is just 4 spaces
         for _ in range(0i, 4) {
-            self.insert_char(' ');
+            self.insert_char(transaction, ' ');
         }
     }
 
-    pub fn insert_char(&mut self, ch: char) {
-        self.cursor().insert_char(ch);
+    pub fn insert_char(&mut self, transaction: &mut Transaction, ch: char) {
+        self.cursor().insert_char(transaction, ch);
     }
 
-    pub fn insert_line(&mut self) {
-        let (offset, line_num) = self.cursor().get_position();
-        self.buffer.insert_line(offset, line_num);
+    pub fn insert_line(&mut self, transaction: &mut Transaction,) {
+        let CursorData { offset, linenum } = self.cursor().get_position();
+        self.buffer.insert_line(transaction, offset, linenum);
 
         self.move_cursor_down();
         self.cursor().set_offset(0);
+    }
+
+    pub fn replay(&mut self, entry: &LogEntry) {
+        let LogEntry { ref changes, ref cursor_end, .. } = *entry;
+        for change in changes.iter() {
+            self.buffer.replay(change);
+        }
+        self.cursor_data = *cursor_end;
     }
 }
 
@@ -339,7 +353,8 @@ pub fn draw_line(buf: &mut UIBuffer, line: &Line, top_line_num: uint) {
 mod tests {
 
     use buffer::{Line, Buffer};
-    use cursor::{Direction};
+    use cursor::{CursorData, Direction};
+    use log::LogEntries;
     use view::View;
     use uibuf::UIBuffer;
     use utils::data_from_str;
@@ -348,8 +363,10 @@ mod tests {
         let mut view = View {
             buffer: Buffer::new(),
             top_line_num: 0,
-            linenum: 0,
-            offset: 0,
+            cursor_data: CursorData {
+                linenum: 0,
+                offset: 0,
+            },
             uibuf: UIBuffer::new(50, 50),
             threshold: 5,
         };
@@ -384,8 +401,10 @@ mod tests {
     #[test]
     fn test_insert_line() {
         let mut view = setup_view();
+        let mut log = LogEntries::new();
+        let mut transaction = log.start(view.cursor_data);
         view.cursor().move_right();
-        view.insert_line();
+        view.insert_line(&mut transaction);
 
         assert_eq!(view.buffer.lines.len(), 3);
         assert_eq!(view.cursor().get_offset(), 0);
@@ -395,7 +414,9 @@ mod tests {
     #[test]
     fn test_insert_char() {
         let mut view = setup_view();
-        view.insert_char('t');
+        let mut log = LogEntries::new();
+        let mut transaction = log.start(view.cursor_data);
+        view.insert_char(&mut transaction, 't');
 
         assert_eq!(view.cursor().get_line().data, data_from_str("ttest"));
     }
@@ -403,7 +424,9 @@ mod tests {
     #[test]
     fn test_delete_char_to_right() {
         let mut view = setup_view();
-        view.delete_char(Direction::Right);
+        let mut log = LogEntries::new();
+        let mut transaction = log.start(view.cursor_data);
+        view.delete_char(&mut transaction, Direction::Right);
 
         assert_eq!(view.cursor().get_line().data, data_from_str("est"));
     }
@@ -411,8 +434,10 @@ mod tests {
     #[test]
     fn test_delete_char_to_left() {
         let mut view = setup_view();
+        let mut log = LogEntries::new();
+        let mut transaction = log.start(view.cursor_data);
         view.cursor().move_right();
-        view.delete_char(Direction::Left);
+        view.delete_char(&mut transaction, Direction::Left);
 
         assert_eq!(view.cursor().get_line().data, data_from_str("est"));
     }
@@ -420,8 +445,10 @@ mod tests {
     #[test]
     fn test_delete_char_at_start_of_line() {
         let mut view = setup_view();
+        let mut log = LogEntries::new();
+        let mut transaction = log.start(view.cursor_data);
         view.move_cursor_down();
-        view.delete_char(Direction::Left);
+        view.delete_char(&mut transaction, Direction::Left);
 
         assert_eq!(view.cursor().get_line().data, data_from_str("testsecond"));
     }
@@ -429,8 +456,10 @@ mod tests {
     #[test]
     fn test_delete_char_at_end_of_line() {
         let mut view = setup_view();
-        view.offset = 4;
-        view.delete_char(Direction::Right);
+        let mut log = LogEntries::new();
+        let mut transaction = log.start(view.cursor_data);
+        view.cursor_data.offset = 4;
+        view.delete_char(&mut transaction, Direction::Right);
 
         assert_eq!(view.cursor().get_line().data, data_from_str("testsecond"));
     }
@@ -438,16 +467,20 @@ mod tests {
     #[test]
     fn delete_char_when_line_is_empty_does_nothing() {
         let mut view = setup_view();
+        let mut log = LogEntries::new();
+        let mut transaction = log.start(view.cursor_data);
         view.buffer.lines = vec!(Line::new(String::new(), 0));
-        view.linenum = 0;
-        view.delete_char(Direction::Right);
+        view.cursor_data.linenum = 0;
+        view.delete_char(&mut transaction, Direction::Right);
         assert_eq!(view.cursor().get_line().data, data_from_str(""));
     }
 
     #[test]
     fn deleting_backward_at_start_of_first_line_does_nothing() {
         let mut view = setup_view();
-        view.delete_char(Direction::Left);
+        let mut log = LogEntries::new();
+        let mut transaction = log.start(view.cursor_data);
+        view.delete_char(&mut transaction, Direction::Left);
 
         assert_eq!(view.buffer.lines.len(), 2);
         assert_eq!(view.cursor().get_line().data, data_from_str("test"));


### PR DESCRIPTION
This involves adding transactional semantics to all commands that modify
data.  This is explicitly _not_ optimized right now, but is instead as
simple as possible.  If it proves damaging in the immediate term, we can
easily bound the size of the undo/redo stack.

Undo/redo are CTRL + Z and CTRL + Y.  As far as I can tell, they work, with no caveats.

This builds off the commit that fixes deletion at end of line.
