### PR TITLE
Word movement & deletion vi commands

### DIFF
--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -370,7 +370,7 @@ mod test {
     #[test]
     fn test_remove() {
         let mut buffer = setup_buffer("ABCD");
-        buffer.remove_char(Mark::Cursor(0));
+        buffer.remove_chars(Mark::Cursor(0), Direction::Right(1));
 
         assert_eq!(buffer.len(), 4);
         assert_eq!(buffer.lines().next().unwrap(), [b'B', b'C', b'D']);

--- a/src/iota/modes/mod.rs
+++ b/src/iota/modes/mod.rs
@@ -5,6 +5,7 @@ pub use super::editor::Command;
 pub use super::view::View;
 pub use super::keymap::KeyMapState;
 pub use super::buffer::Direction;
+pub use super::buffer::WordEdgeMatch;
 pub use super::Response;
 pub use super::utils;
 pub use super::overlay::{Overlay, OverlayType, OverlayEvent};

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -43,7 +43,12 @@ impl NormalMode {
         keymap.bind_key(Key::Char('$'), Command::LineEnd);
 
         // editing
+        keymap.bind_keys(&[Key::Char('d'), Key::Char('W')], Command::Delete(Direction::RightWord(1, true)));
+        keymap.bind_keys(&[Key::Char('d'), Key::Char('B')], Command::Delete(Direction::LeftWord(1, true)));
+        keymap.bind_keys(&[Key::Char('d'), Key::Char('w')], Command::Delete(Direction::RightWord(1, false)));
+        keymap.bind_keys(&[Key::Char('d'), Key::Char('b')], Command::Delete(Direction::LeftWord(1, false)));
         keymap.bind_key(Key::Char('x'), Command::Delete(Direction::Right(1)));
+        keymap.bind_key(Key::Char('X'), Command::Delete(Direction::Left(1)));
         keymap.bind_key(Key::Char('u'), Command::Undo);
         keymap.bind_key(Key::Ctrl('r'), Command::Redo);
 
@@ -65,7 +70,7 @@ impl NormalMode {
             Command::LineStart       => view.move_cursor_to_line_start(),
 
             // Editing
-            Command::Delete(dir)     => view.delete_char(dir),
+            Command::Delete(dir)     => view.delete_chars(dir),
             Command::Redo            => view.redo(),
             Command::Undo            => view.undo(),
 

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -6,6 +6,7 @@ use super::View;
 use super::KeyMapState;
 use super::EventStatus;
 use super::Direction;
+use super::WordEdgeMatch;
 use super::Response;
 use super::utils;
 use super::{Overlay, OverlayType, OverlayEvent};
@@ -35,18 +36,18 @@ impl NormalMode {
         keymap.bind_key(Key::Char('j'), Command::MoveCursor(Direction::Down(1)));
         keymap.bind_key(Key::Char('k'), Command::MoveCursor(Direction::Up(1)));
         keymap.bind_key(Key::Char('l'), Command::MoveCursor(Direction::Right(1)));
-        keymap.bind_key(Key::Char('W'), Command::MoveCursor(Direction::RightWord(1, true)));
-        keymap.bind_key(Key::Char('B'), Command::MoveCursor(Direction::LeftWord(1, true)));
-        keymap.bind_key(Key::Char('w'), Command::MoveCursor(Direction::RightWord(1, false)));
-        keymap.bind_key(Key::Char('b'), Command::MoveCursor(Direction::LeftWord(1, false)));
+        keymap.bind_key(Key::Char('W'), Command::MoveCursor(Direction::RightWord(1, WordEdgeMatch::Whitespace)));
+        keymap.bind_key(Key::Char('B'), Command::MoveCursor(Direction::LeftWord(1, WordEdgeMatch::Whitespace)));
+        keymap.bind_key(Key::Char('w'), Command::MoveCursor(Direction::RightWord(1, WordEdgeMatch::Alphabet)));
+        keymap.bind_key(Key::Char('b'), Command::MoveCursor(Direction::LeftWord(1, WordEdgeMatch::Alphabet)));
         keymap.bind_key(Key::Char('^'), Command::LineStart);
         keymap.bind_key(Key::Char('$'), Command::LineEnd);
 
         // editing
-        keymap.bind_keys(&[Key::Char('d'), Key::Char('W')], Command::Delete(Direction::RightWord(1, true)));
-        keymap.bind_keys(&[Key::Char('d'), Key::Char('B')], Command::Delete(Direction::LeftWord(1, true)));
-        keymap.bind_keys(&[Key::Char('d'), Key::Char('w')], Command::Delete(Direction::RightWord(1, false)));
-        keymap.bind_keys(&[Key::Char('d'), Key::Char('b')], Command::Delete(Direction::LeftWord(1, false)));
+        keymap.bind_keys(&[Key::Char('d'), Key::Char('W')], Command::Delete(Direction::RightWord(1, WordEdgeMatch::Whitespace)));
+        keymap.bind_keys(&[Key::Char('d'), Key::Char('B')], Command::Delete(Direction::LeftWord(1, WordEdgeMatch::Whitespace)));
+        keymap.bind_keys(&[Key::Char('d'), Key::Char('w')], Command::Delete(Direction::RightWord(1, WordEdgeMatch::Alphabet)));
+        keymap.bind_keys(&[Key::Char('d'), Key::Char('b')], Command::Delete(Direction::LeftWord(1, WordEdgeMatch::Alphabet)));
         keymap.bind_key(Key::Char('x'), Command::Delete(Direction::Right(1)));
         keymap.bind_key(Key::Char('X'), Command::Delete(Direction::Left(1)));
         keymap.bind_key(Key::Char('u'), Command::Undo);

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -35,6 +35,10 @@ impl NormalMode {
         keymap.bind_key(Key::Char('j'), Command::MoveCursor(Direction::Down(1)));
         keymap.bind_key(Key::Char('k'), Command::MoveCursor(Direction::Up(1)));
         keymap.bind_key(Key::Char('l'), Command::MoveCursor(Direction::Right(1)));
+        keymap.bind_key(Key::Char('W'), Command::MoveCursor(Direction::RightWord(1, true)));
+        keymap.bind_key(Key::Char('B'), Command::MoveCursor(Direction::LeftWord(1, true)));
+        keymap.bind_key(Key::Char('w'), Command::MoveCursor(Direction::RightWord(1, false)));
+        keymap.bind_key(Key::Char('b'), Command::MoveCursor(Direction::LeftWord(1, false)));
         keymap.bind_key(Key::Char('^'), Command::LineStart);
         keymap.bind_key(Key::Char('$'), Command::LineEnd);
 

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -79,7 +79,7 @@ impl StandardMode {
             Command::LineStart       => view.move_cursor_to_line_start(),
 
             // Editing
-            Command::Delete(dir)     => view.delete_char(dir),
+            Command::Delete(dir)     => view.delete_chars(dir),
             Command::InsertTab       => view.insert_tab(),
             Command::InsertChar(c)   => view.insert_char(c),
             Command::Redo            => view.redo(),

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -178,14 +178,14 @@ impl<'v> View<'v> {
 
     //----- TEXT EDIT METHODS ----------------------------------------------------------------------
 
-    pub fn delete_char(&mut self, direction: Direction) {
-        match direction {
-            Direction::Left(1) if self.buffer.get_mark_idx(self.cursor) != Some(0) => {
-                self.move_cursor(direction);
-                self.buffer.remove_char(self.cursor);
+    pub fn delete_chars(&mut self, direction: Direction) {
+        let chars = self.buffer.remove_chars(self.cursor, direction);
+        match (chars, direction) {
+            (Some(chars), Direction::Left(..)) => {
+                self.move_cursor(Direction::Left(chars.len()));
             }
-            Direction::Right(1) if self.buffer.get_mark_idx(self.cursor) != Some(self.buffer.len()) => {
-                self.buffer.remove_char(self.cursor);
+            (Some(chars), Direction::LeftWord(..)) => {
+                self.move_cursor(Direction::Left(chars.len()));
             }
             _ => {}
         }

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -295,7 +295,7 @@ mod tests {
     #[test]
     fn test_delete_char_to_right() {
         let mut view = setup_view("test\nsecond");
-        view.delete_char(Direction::Right(1));
+        view.delete_chars(Direction::Right(1));
 
         assert_eq!(view.buffer.lines().next().unwrap(), b"est\n"[]);
     }
@@ -304,7 +304,7 @@ mod tests {
     fn test_delete_char_to_left() {
         let mut view = setup_view("test\nsecond");
         view.move_cursor(Direction::Right(1));
-        view.delete_char(Direction::Left(1));
+        view.delete_chars(Direction::Left(1));
 
         assert_eq!(view.buffer.lines().next().unwrap(), b"est\n"[]);
     }
@@ -314,7 +314,7 @@ mod tests {
     fn test_delete_char_at_start_of_line() {
         let mut view = setup_view("test\nsecond");
         view.move_cursor(Direction::Down(1));
-        view.delete_char(Direction::Left(1));
+        view.delete_chars(Direction::Left(1));
 
         assert_eq!(view.buffer.lines().next().unwrap(), b"testsecond"[]);
     }
@@ -323,7 +323,7 @@ mod tests {
     fn test_delete_char_at_end_of_line() {
         let mut view = setup_view("test\nsecond");
         view.move_cursor(Direction::Right(4));
-        view.delete_char(Direction::Right(1));
+        view.delete_chars(Direction::Right(1));
 
         assert_eq!(view.buffer.lines().next().unwrap(), b"testsecond"[]);
     }
@@ -331,7 +331,7 @@ mod tests {
     #[test]
     fn deleting_backward_at_start_of_first_line_does_nothing() {
         let mut view = setup_view("test\nsecond");
-        view.delete_char(Direction::Left(1));
+        view.delete_chars(Direction::Left(1));
 
         let lines: Vec<&[u8]> = view.buffer.lines().collect();
 


### PR DESCRIPTION
Still slightly inconsistent with `vim` with deleting words at the end of a line/blank lines. Also I'm not very happy about using a boolean in the `Direction` enum for the different `vim` word matching types, thinking maybe adding another enum that defines the word edge matching might be the way to go. Would allow for adding in whatever emacs bindings there are for moving by word easily.

So, with those above caveats this is more of a review/discussion request than a serious pull request, yet.