### PR TITLE
Fixing iota to work with new GapBuffer.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "iota"
 version = "0.1.0"
 dependencies = [
  "docopt 0.6.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "gapbuffer 0.0.3 (git+https://github.com/dlaronson/gapbuffer)",
+ "gapbuffer 0.0.4 (git+https://github.com/dlaronson/gapbuffer)",
  "rustbox 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -19,8 +19,8 @@ dependencies = [
 
 [[package]]
 name = "gapbuffer"
-version = "0.0.3"
-source = "git+https://github.com/dlaronson/gapbuffer#75708d3f33a3af9a5809745cb2118bd8cc5f0c69"
+version = "0.0.4"
+source = "git+https://github.com/dlaronson/gapbuffer#c9b5cde39e03ebd8f6ab2a8df12f90e7a595c8ec"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rustc-serialize = "0.2.7"
 
 [dependencies.gapbuffer]
 git = "https://github.com/dlaronson/gapbuffer"
+version = "0.0.4"
 
 [lib]
 name = "iota"

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -105,7 +105,7 @@ impl<'v> View<'v> {
                                 .unwrap()
                                 .take(self.get_height())
                                 .enumerate() {
-            draw_line(&mut self.uibuf, line, index, self.left_col);
+            draw_line(&mut self.uibuf, &*line, index, self.left_col);
             if index == self.get_height() { break; }
         }
 
@@ -281,7 +281,7 @@ impl<'v> View<'v> {
 
         //TODO (lee): Is iteration still necessary in this format?
         for line in self.buffer.lines() {
-            let result = file.write(line);
+            let result = file.write(&*line);
 
             if result.is_err() {
                 // TODO(greg): figure out what to do here.
@@ -427,7 +427,7 @@ mod tests {
         let mut view = setup_view("test\nsecond");
         view.delete_chars(Direction::Left, 1);
 
-        let lines: Vec<&[u8]> = view.buffer.lines().collect();
+        let lines: Vec<_> = view.buffer.lines().collect();
 
         assert_eq!(lines.len(), 2);
         assert_eq!(view.buffer.lines().next().unwrap(), b"test\n");


### PR DESCRIPTION
Note that this commit holds off on modifying the Cargo.toml until some
minor fixes have been merged into GapBuffer proper.  A subsequent commit
will change this to point to the correct commit.  Do not merge until the second commit.