### PR TITLE
Traverse buffer by chars

### DIFF
--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -1,6 +1,7 @@
 //FIXME: Check unicode support
 // stdlib dependencies
 use std::cmp;
+use std::mem;
 use std::collections::HashMap;
 use std::io::{File, Reader, BufferedReader};
 
@@ -387,11 +388,36 @@ impl<'a> Iterator for Lines<'a> {
 
 }
 
+/// Iterator traversing GapBuffer as chars
+/// Can be made to traverse forwards or backwards with the methods
+/// `rev()` `forward()` and `backward()`
 pub struct Chars<'a> {
     buffer: &'a GapBuffer<u8>,
     idx: usize,
     forward: bool,
 }
+
+// helper macros/constants
+// u8 -> char code is mostly copied from core::str::Chars
+const CONT_MASK:   u8 = 0b0011_1111u8;
+const TAG_CONT_U8: u8 = 0b1000_0000u8;
+
+// Return the initial codepoint accumulator for the first byte.
+// The first byte is special, only want bottom 5 bits for width 2, 4 bits
+// for width 3, and 3 bits for width 4
+macro_rules! utf8_first_byte {
+    ($byte:expr, $width:expr) => (($byte & (0x7F >> $width)) as u32)
+}
+
+// return the value of $ch updated with continuation byte $byte
+macro_rules! utf8_acc_cont_byte {
+    ($ch:expr, $byte:expr) => (($ch << 6) | ($byte & CONT_MASK) as u32)
+}
+
+macro_rules! utf8_is_cont_byte {
+    ($byte:expr) => (($byte & !CONT_MASK) == TAG_CONT_U8)
+}
+
 
 impl<'a> Chars<'a> {
     pub fn rev(mut self) -> Chars<'a> {
@@ -406,19 +432,92 @@ impl<'a> Chars<'a> {
         self.forward = false;
         self
     }
+
+    fn next_u8(&mut self) -> Option<u8> {
+        let n = if self.idx < self.buffer.len() {
+            Some(self.buffer[self.idx])
+        } else { None };
+        self.idx += if self.forward { 1 } else { -1 };
+        n
+    }
 }
 
 impl<'a> Iterator for Chars<'a> {
-    type Item = u8;
+    type Item = char;
     
-    fn next(&mut self) -> Option<u8> {
-        let n = if self.idx < self.buffer.len() {
-            Some(self.buffer[self.idx])
+    #[inline]
+    fn next(&mut self) -> Option<char> {
+        if self.forward {
+            // read u8s forwards into char (largely copied from core::str::Chars)
+
+            let x = match self.next_u8() {
+                None => return None,
+                Some(next_byte) if next_byte < 128 => return Some(next_byte as char),
+                Some(next_byte) => next_byte
+            };
+            
+            //print!("\n forward multibyte start: [{:x}", x);
+
+            // Multibyte case follows
+            // Decode from a byte combination out of: [[[x y] z] w]
+            let init = utf8_first_byte!(x, 2);
+            let y = self.next_u8().unwrap_or(0);
+            //print!(" {:x}", y);
+            let mut ch = utf8_acc_cont_byte!(init, y);
+            if x >= 0xE0 {
+                // [[x y z] w] case
+                // 5th bit in 0xE0 .. 0xEF is always clear, so `init` is still valid
+                let z = self.next_u8().unwrap_or(0);
+                //print!(" {:x}", z);
+                let y_z = utf8_acc_cont_byte!((y & CONT_MASK) as u32, z);
+                ch = init << 12 | y_z;
+                if x >= 0xF0 {
+                    // [x y z w] case
+                    // use only the lower 3 bits of `init`
+                    let w = self.next_u8().unwrap_or(0);
+                    //print!(" {:x}", w);
+                    ch = (init & 7) << 18 | utf8_acc_cont_byte!(y_z, w);
+                }
+            }
+            //print!("]: {} ({:x})\n", unsafe { mem::transmute::<u32, char>(ch) }, ch);
+
+            // str invariant says `ch` is a valid Unicode Scalar Value
+            return unsafe { Some(mem::transmute(ch)) };
         } else {
-            None
-        };
-        self.idx += if self.forward { 1 } else { -1 };
-        n
+            // read u8s backwards into char (largely copied from core::str::Chars)
+            let w = match self.next_u8() {
+                None => return None,
+                Some(back_byte) if back_byte < 128 => return Some(back_byte as char),
+                Some(back_byte) => back_byte,
+            };
+
+            //print!("\nbackward multibyte start: [{:x}", w);
+
+            // Multibyte case follows
+            // Decode from a byte combination out of: [x [y [z w]]]
+            let mut ch;
+            let z = self.next_u8().unwrap_or(0);
+            //print!(" {:x}", z);
+            ch = utf8_first_byte!(z, 2);
+            if utf8_is_cont_byte!(z) {
+                let y = self.next_u8().unwrap_or(0);
+                //print!(" {:x}", y);
+                ch = utf8_first_byte!(y, 3);
+                if utf8_is_cont_byte!(y) {
+                    let x = self.next_u8().unwrap_or(0);
+                    //print!(" {:x}", x);
+                    ch = utf8_first_byte!(x, 4);
+                    ch = utf8_acc_cont_byte!(ch, y);
+                }
+                ch = utf8_acc_cont_byte!(ch, z);
+            }
+            ch = utf8_acc_cont_byte!(ch, w);
+
+            //print!("]: {} ({:x})\n", unsafe { mem::transmute::<u32, char>(ch) }, ch);
+
+            // str invariant says `ch` is a valid Unicode Scalar Value
+            return unsafe { Some(mem::transmute(ch)) };
+        }
     }
 }
 
@@ -533,32 +632,36 @@ mod test {
 
     #[test]
     fn test_to_chars() {
-        let mut buffer = setup_buffer("Test");
+        let mut buffer = setup_buffer("Test𐍈Test");
         buffer.set_mark(Mark::Cursor(0), 0);
         let mut chars = buffer.chars();
-        assert!(chars.next().unwrap() == 'T' as u8);
-        assert!(chars.next().unwrap() == 'e' as u8);
-        assert!(chars.next().unwrap() == 's' as u8);
-        assert!(chars.next().unwrap() == 't' as u8);
+        assert!(chars.next().unwrap() == 'T');
+        assert!(chars.next().unwrap() == 'e');
+        assert!(chars.next().unwrap() == 's');
+        assert!(chars.next().unwrap() == 't');
+        assert!(chars.next().unwrap() == '𐍈');
+        assert!(chars.next().unwrap() == 'T');
     }
 
     #[test]
     fn test_to_chars_from() {
-        let mut buffer = setup_buffer("Test");
+        let mut buffer = setup_buffer("Test𐍈Test");
         buffer.set_mark(Mark::Cursor(0), 2);
         let mut chars = buffer.chars_from(Mark::Cursor(0)).unwrap();
-        assert!(chars.next().unwrap() == 's' as u8);
-        assert!(chars.next().unwrap() == 't' as u8);
+        assert!(chars.next().unwrap() == 's');
+        assert!(chars.next().unwrap() == 't');
+        assert!(chars.next().unwrap() == '𐍈');
     }
 
     #[test]
     fn test_to_chars_rev() {
-        let mut buffer = setup_buffer("Test");
-        buffer.set_mark(Mark::Cursor(0), 2);
+        // 𐍈 encodes as utf8 in 4 bytes... we need a solution for buffer offsets by byte/char
+        let mut buffer = setup_buffer("Test𐍈Test");
+        buffer.set_mark(Mark::Cursor(0), 8);
         let mut chars = buffer.chars_from(Mark::Cursor(0)).unwrap().rev();
-        assert!(chars.next().unwrap() == 's' as u8);
-        assert!(chars.next().unwrap() == 'e' as u8);
-        assert!(chars.next().unwrap() == 'T' as u8);
+        assert!(chars.next().unwrap() == 'T');
+        assert!(chars.next().unwrap() == '𐍈');
+        assert!(chars.next().unwrap() == 't');
     }
 
     #[test]


### PR DESCRIPTION
I've copied the `core::str::Chars` iterator code into an special iterator struct in the buffer module.
This allows us to iterate forward/backward from any mark by `char`s instead of `u8`s.