### PR TITLE
Implement comand builder & text objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "docopt 0.6.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "gapbuffer 0.0.5 (git+https://github.com/dlaronson/gapbuffer)",
  "rustbox 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -19,7 +19,7 @@ version = "0.6.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "regex 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-serialize"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Greg Chapple <gregchapple1@gmail.com>"]
 [dependencies]
 docopt = "0.6.37"
 rustbox = "0.3.0"
-rustc-serialize = "0.2.12"
+rustc-serialize = "0.2.13"
 
 [dependencies.gapbuffer]
 git = "https://github.com/dlaronson/gapbuffer"

--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -239,14 +239,8 @@ impl Buffer {
             match anchor {
                 Anchor::End | Anchor::Before => -1,
                 Anchor::Same => {
-                    // to get the offset from the start of the line:
-                    // 1. get the absolute index of the start of the current line
-                    let current_line_start_index = get_line(start, &self.text).unwrap();
-                    // 2. subtract that from the current offset
-                    let offset_from_start_of_line = start - current_line_start_index;
-
-
-                    offset_from_start_of_line as i32
+                    let (current_line_offset, _) = self.get_mark_coords(Mark::Cursor(0)).unwrap();
+                    current_line_offset as i32
                 }
                 _ => 0
             }

--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -238,6 +238,16 @@ impl Buffer {
             // we're moving forwards
             match anchor {
                 Anchor::End | Anchor::Before => -1,
+                Anchor::Same => {
+                    // to get the offset from the start of the line:
+                    // 1. get the absolute index of the start of the current line
+                    let current_line_start_index = get_line(start, &self.text).unwrap();
+                    // 2. subtract that from the current offset
+                    let offset_from_start_of_line = start - current_line_start_index;
+
+
+                    offset_from_start_of_line as i32
+                }
                 _ => 0
             }
         } else {

--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -308,116 +308,116 @@ impl Buffer {
     /// Sets the mark to the location of a given TextObject, if it exists.
     /// Adds a new mark or overwrites an existing mark.
     pub fn set_mark_to_object(&mut self, mark: Mark, obj: TextObject) {
-        let last = self.len() - 1;
-        let text = &self.text;
-        if let Some(tuple) = self.marks.get_mut(&mark) {
-            let (index, line_index) = *tuple;
+        // let last = self.len() - 1;
+        // let text = &self.text;
+        // if let Some(tuple) = self.marks.get_mut(&mark) {
+        //     let (index, line_index) = *tuple;
+        //     print!("{:?}", obj);
+        //     *tuple = match obj.kind {
+        //         Kind::Char => {
+        //             match obj.offset {
+        //                 Offset::Forward(offset, _) => {
+        //                     let absolute_index = index + offset;
+        //                     if absolute_index < last {
+        //                         (absolute_index, absolute_index - get_line(absolute_index, text).unwrap())
+        //                     } else {
+        //                         (last, last - get_line(last, text).unwrap())
+        //                     }
+        //                 }
 
-            *tuple = match obj.kind {
-                Kind::Char => {
-                    match obj.offset {
-                        Offset::Forward(offset, _) => {
-                            let absolute_index = index + offset;
-                            if absolute_index < last {
-                                (absolute_index, absolute_index - get_line(absolute_index, text).unwrap())
-                            } else {
-                                (last, last - get_line(last, text).unwrap())
-                            }
-                        }
+        //                 Offset::Backward(offset, _) => {
+        //                     if index >= offset {
+        //                         let absolute_index = index - offset;
+        //                         (absolute_index, absolute_index - get_line(absolute_index, text).unwrap())
+        //                     } else {
+        //                         (0, 0)
+        //                     }
+        //                 }
 
-                        Offset::Backward(offset, _) => {
-                            if index >= offset {
-                                let absolute_index = index - offset;
-                                (absolute_index, absolute_index - get_line(absolute_index, text).unwrap())
-                            } else {
-                                (0, 0)
-                            }
-                        }
-
-                        // TODO: find out the usecase for this
-                        Offset::Absolute(_) => (0, 0),
-                    }
-                }
-
-
-                Kind::Line(anchor) => {
-                    match obj.offset {
-                        Offset::Forward(offset, _) => {
-                            let nlines = range(index, text.len()).filter(|i| text[*i] == b'\n')
-                                                               .take(offset + 1)
-                                                               .collect::<Vec<usize>>();
-                            if offset > nlines.len() {
-                                (last, last - get_line(last, text).unwrap())
-                            } else if offset == nlines.len() {
-                                (cmp::min(line_index + nlines[offset-1] + 1, last), line_index)
-                            } else {
-                                (cmp::min(line_index + nlines[offset-1] + 1, nlines[offset]), line_index)
-                            }
-                        }
-
-                        Offset::Backward(offset, _) => {
-                            let nlines = range(0, index).rev().filter(|i| text[*i] == b'\n')
-                                                            .take(offset + 1)
-                                                            .collect::<Vec<usize>>();
-                            if offset == nlines.len() {
-                                (cmp::min(line_index, nlines[0]), line_index)
-                            } else if offset > nlines.len() {
-                                (0, 0)
-                            } else {
-                                (cmp::min(line_index + nlines[offset] + 1, nlines[offset-1]), line_index)
-                            }
-                        }
-
-                        // TODO: find out the usecase for this
-                        Offset::Absolute(_) => (0, 0)
-                    }
-                }
+        //                 // TODO: find out the usecase for this
+        //                 Offset::Absolute(_) => (0, 0),
+        //             }
+        //         }
 
 
-                Kind::Word(anchor) => {
-                    match obj.offset {
-                        Offset::Forward(offset, _) => {
-                            // TODO: use anchor to determine this
-                            let edger = WordEdgeMatch::Whitespace;
+        //         Kind::Line(anchor) => {
+        //             match obj.offset {
+        //                 Offset::Forward(offset, _) => {
+        //                     let nlines = range(index, text.len()).filter(|i| text[*i] == b'\n')
+        //                                                        .take(offset + 1)
+        //                                                        .collect::<Vec<usize>>();
+        //                     if offset > nlines.len() {
+        //                         (last, last - get_line(last, text).unwrap())
+        //                     } else if offset == nlines.len() {
+        //                         (cmp::min(line_index + nlines[offset-1] + 1, last), line_index)
+        //                     } else {
+        //                         (cmp::min(line_index + nlines[offset-1] + 1, nlines[offset]), line_index)
+        //                     }
+        //                 }
 
-                            if let Some(new_idx) = get_words(index, offset, edger, text) {
-                                if new_idx < last {
-                                    (new_idx, new_idx - get_line(new_idx, text).unwrap())
-                                } else {
-                                    (last, last - get_line(last, text).unwrap())
-                                }
-                            } else {
-                                (last, last - get_line(last, text).unwrap())
-                            }
-                        }
+        //                 Offset::Backward(offset, _) => {
+        //                     let nlines = range(0, index).rev().filter(|i| text[*i] == b'\n')
+        //                                                     .take(offset + 1)
+        //                                                     .collect::<Vec<usize>>();
+        //                     if offset == nlines.len() {
+        //                         (cmp::min(line_index, nlines[0]), line_index)
+        //                     } else if offset > nlines.len() {
+        //                         (0, 0)
+        //                     } else {
+        //                         (cmp::min(line_index + nlines[offset] + 1, nlines[offset-1]), line_index)
+        //                     }
+        //                 }
 
-                        Offset::Backward(offset, _) => {
-                            // TODO: use anchor to determine this
-                            let edger = WordEdgeMatch::Whitespace;
-
-                            if let Some(new_idx) = get_words_rev(index, offset, edger, text) {
-                                if new_idx > 0 {
-                                    (new_idx, new_idx - get_line(new_idx, text).unwrap())
-                                } else {
-                                    (0, 0)
-                                }
-                            } else {
-                                (0, 0)
-                            }
-                        }
-
-                        // TODO: find out the usecase for this
-                        Offset::Absolute(_) => (0, 0)
-                    }
-                }
+        //                 // TODO: find out the usecase for this
+        //                 Offset::Absolute(_) => (0, 0)
+        //             }
+        //         }
 
 
-            }
-        }
+        //         Kind::Word(anchor) => {
+        //             match obj.offset {
+        //                 Offset::Forward(offset, _) => {
+        //                     // TODO: use anchor to determine this
+        //                     let edger = WordEdgeMatch::Whitespace;
 
-        // if let Some(idx) = self.get_object_index(obj) {
-        //     self.set_mark(mark, idx);
+        //                     if let Some(new_idx) = get_words(index, offset, edger, text) {
+        //                         if new_idx < last {
+        //                             (new_idx, new_idx - get_line(new_idx, text).unwrap())
+        //                         } else {
+        //                             (last, last - get_line(last, text).unwrap())
+        //                         }
+        //                     } else {
+        //                         (last, last - get_line(last, text).unwrap())
+        //                     }
+        //                 }
+
+        //                 Offset::Backward(offset, _) => {
+        //                     // TODO: use anchor to determine this
+        //                     let edger = WordEdgeMatch::Whitespace;
+
+        //                     if let Some(new_idx) = get_words_rev(index, offset, edger, text) {
+        //                         if new_idx > 0 {
+        //                             (new_idx, new_idx - get_line(new_idx, text).unwrap())
+        //                         } else {
+        //                             (0, 0)
+        //                         }
+        //                     } else {
+        //                         (0, 0)
+        //                     }
+        //                 }
+
+        //                 // TODO: find out the usecase for this
+        //                 Offset::Absolute(_) => (0, 0)
+        //             }
+        //         }
+
+
+        //     }
         // }
+
+        if let Some(idx) = self.get_object_index(obj) {
+            self.set_mark(mark, idx);
+        }
     }
 
     /// Sets the mark to a given absolute index. Adds a new mark or overwrites an existing mark.
@@ -654,12 +654,192 @@ fn commit(transaction: &LogEntry, text: &mut GapBuffer<u8>) {
 mod test {
 
     use buffer::{Buffer, Direction, Mark};
+    use textobject::{TextObject, Offset, Kind, Anchor};
 
     fn setup_buffer(testcase: &'static str) -> Buffer {
         let mut buffer = Buffer::new();
         buffer.text.extend(testcase.bytes());
         buffer.set_mark(Mark::Cursor(0), 0);
         buffer
+    }
+
+    #[test]
+    fn move_mark_textobject_char_right() {
+        let mut buffer = setup_buffer("Some test content");
+        let mark = Mark::Cursor(0);
+        let obj = TextObject {
+            kind: Kind::Char,
+            offset: Offset::Forward(1, mark),
+        };
+
+        buffer.set_mark_to_object(mark, obj);
+        
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(1, 1));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (1, 0));
+    }
+
+    #[test]
+    fn move_mark_textobject_char_left() {
+        let mut buffer = setup_buffer("Some test content");
+        let mark = Mark::Cursor(0);
+        let obj = TextObject {
+            kind: Kind::Char,
+            offset: Offset::Backward(1, mark),
+        };
+
+        buffer.set_mark(mark, 3);
+        buffer.set_mark_to_object(mark, obj);
+        
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(2, 2));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (2, 0));
+    }
+    
+    #[test]
+    fn move_mark_textobject_five_chars_right() {
+        let mut buffer = setup_buffer("Some test content");
+        let mark = Mark::Cursor(0);
+        let obj = TextObject {
+            kind: Kind::Char,
+            offset: Offset::Forward(5, mark),
+        };
+
+        buffer.set_mark_to_object(mark, obj);
+        
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(5, 5));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (5, 0));
+    }
+
+    #[test]
+    fn move_mark_textobject_line_down() {
+        let mut buffer = setup_buffer("Some test content\nnew lines!");
+        let mark = Mark::Cursor(0);
+        let obj = TextObject {
+            kind: Kind::Line(Anchor::Same),
+            offset: Offset::Forward(1, mark),
+        };
+
+        buffer.set_mark_to_object(mark, obj);
+        
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(18, 0));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (0, 1));
+    }
+
+    #[test]
+    fn move_mark_textobject_line_up() {
+        let mut buffer = setup_buffer("Some test content\nnew lines!");
+        let mark = Mark::Cursor(0);
+        let obj = TextObject {
+            kind: Kind::Line(Anchor::Same),
+            offset: Offset::Backward(1, mark),
+        };
+
+        buffer.set_mark(mark, 18);
+        buffer.set_mark_to_object(mark, obj);
+        
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(0, 0));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (0, 0));
+    }
+
+    #[test]
+    fn move_mark_textobject_two_lines_down() {
+        let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
+        let mark = Mark::Cursor(0);
+        let obj = TextObject {
+            kind: Kind::Line(Anchor::Same),
+            offset: Offset::Forward(2, mark),
+        };
+
+        buffer.set_mark_to_object(mark, obj);
+        
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(27, 0));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (0, 2));
+    }
+
+    #[test]
+    fn move_mark_textobject_line_down_to_shorter_line() {
+        let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
+        let mark = Mark::Cursor(0);
+        let obj = TextObject {
+            kind: Kind::Line(Anchor::Same),
+            offset: Offset::Forward(1, mark),
+        };
+
+        buffer.set_mark(mark, 15);
+        buffer.set_mark_to_object(mark, obj);
+
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(26, 15));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (8, 1));
+
+        let obj = TextObject {
+            kind: Kind::Line(Anchor::Same),
+            offset: Offset::Backward(1, mark),
+        };
+        buffer.set_mark_to_object(mark, obj);
+        
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(15, 15));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (15, 0));
+    }
+
+    #[test]
+    fn move_mark_textobject_two_words_right() {
+        let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
+        let mark = Mark::Cursor(0);
+        let obj = TextObject {
+            kind: Kind::Word(Anchor::Start),
+            offset: Offset::Forward(2, mark),
+        };
+
+        buffer.set_mark_to_object(mark, obj);
+
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(10, 10));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (10, 0));
+    }
+
+    #[test]
+    fn move_mark_textobject_second_word_in_buffer() {
+        let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
+        let mark = Mark::Cursor(0);
+        let obj = TextObject {
+            kind: Kind::Word(Anchor::Start),
+            offset: Offset::Absolute(2),
+        };
+
+        buffer.set_mark(mark, 18);
+        buffer.set_mark_to_object(mark, obj);
+
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(10, 10));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (10, 0));
+    }
+
+    #[test]
+    fn move_mark_textobject_second_line_in_buffer() {
+        let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
+        let mark = Mark::Cursor(0);
+        let obj = TextObject {
+            kind: Kind::Line(Anchor::Start),
+            offset: Offset::Absolute(2),
+        };
+
+        buffer.set_mark_to_object(mark, obj);
+
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(18, 0));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (18, 1));
+    }
+
+    #[test]
+    fn move_mark_textobject_second_char_in_buffer() {
+        let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
+        let mark = Mark::Cursor(0);
+        let obj = TextObject {
+            kind: Kind::Char,
+            offset: Offset::Absolute(2),
+        };
+
+        buffer.set_mark(mark, 18);
+        buffer.set_mark_to_object(mark, obj);
+
+        assert_eq!(buffer.marks.get(&mark).unwrap(), &(2, 2));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (2, 0));
     }
 
     #[test]

--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -174,12 +174,27 @@ impl Buffer {
         }
     }
 
+    /// Get the absolute index of a specific character in the buffer
+    ///
+    /// This character can be at an absolute position, or a postion relative
+    /// to a given mark.
+    ///
+    /// The absolute offset is in the form (index, line_index) where:
+    ///     index = the offset from the start of the buffer
+    ///     line_index = the offset from the start of the current line
+    ///
+    /// ie: get the index of the 7th character after the cursor
+    /// or: get the index of the 130th character from the start of the buffer
     fn get_char_index(&self, offset: Offset) -> Option<(usize, usize)> {
-        let last = self.len() - 1;
         let text = &self.text;
 
         match offset {
+            // get the index of the char `offset` chars in front of `mark`
+            //
+            // ie: get the index of the char which is X chars in front of the MARK
+            // or: get the index of the char which is 5 chars in front of the Cursor
             Offset::Forward(offset, from_mark) => {
+                let last = self.len() - 1;
                 if let Some(tuple)= self.marks.get(&from_mark) {
                     let (index, _) = *tuple;
                     let absolute_index = index + offset;
@@ -193,6 +208,10 @@ impl Buffer {
                 }
             }
 
+            // get the index of the char `offset` chars before of `mark`
+            //
+            // ie: get the index of the char which is X chars before the MARK
+            // or: get the index of the char which is 5 chars before the Cursor
             Offset::Backward(offset, from_mark) => {
                 if let Some(tuple)= self.marks.get(&from_mark) {
                     let (index, _) = *tuple;
@@ -207,6 +226,9 @@ impl Buffer {
                 }
             }
 
+            // get the index of the char at position `offset` in the buffer
+            //
+            // ie: get the index of the 5th char in the buffer
             Offset::Absolute(absolute_char_offset) => {
                 Some((absolute_char_offset, absolute_char_offset - get_line(absolute_char_offset, text).unwrap()))
             },

--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -335,7 +335,7 @@ impl Buffer {
                         }
 
                         Offset::Absolute(absolute_char_offset) => {
-                            (absolute_char_offset, absolute_char_offset)
+                            (absolute_char_offset, absolute_char_offset - get_line(absolute_char_offset, text).unwrap())
                         },
                     }
                 }

--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -16,8 +16,11 @@ use textobject::{TextObject, Kind, Offset, Anchor};
 
 #[derive(Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Mark {
-    Cursor(usize),           //For keeping track of cursors.
-    DisplayMark(usize),      //For using in determining some display of characters.
+    /// For keeping track of cursors.
+    Cursor(usize),
+    
+    /// For using in determining some display of characters
+    DisplayMark(usize),
 }
 
 #[derive(Copy, PartialEq, Eq, Debug)]
@@ -217,11 +220,29 @@ impl Buffer {
         }
     }
 
+    /// Get the absolute index of a specific line in the buffer
+    ///
+    /// This line can be at an absolute position, or a postion relative
+    /// to a given mark.
+    ///
+    /// The absolute offset is in the form (index, line_index) where:
+    ///     index = the offset from the start of the buffer
+    ///     line_index = the offset from the start of the current line
+    ///
+    /// The index is calculated based on a given Anchor. This Anchor determines
+    /// where in the line the index is calculated. For instance, if you want
+    /// the index of the start of the line, you would use Anchor::Start. If you
+    /// are on the 5th char in a line, and want to get the index of the 5th char
+    /// in another line, you can use Anchor::Same.
+    ///
+    /// ie: get the index of the middle of the 7th line after the cursor
+    /// or: get the index of the start of the 130th line from the start of the buffer
     fn get_line_index(&self, offset: Offset, anchor: Anchor) -> Option<(usize, usize)> {
         let text = &self.text;
         let last = self.len() - 1;
 
         match offset {
+            // The desired line is below the current line - ie moving down
             Offset::Forward(offset, from_mark) => {
                 if let Some(tuple) = self.marks.get(&from_mark) {
                     let (index, line_index) = *tuple;
@@ -230,6 +251,11 @@ impl Buffer {
                                                        .collect::<Vec<usize>>();
 
                     match anchor {
+                        // Get the same index as the current line_index
+                        //
+                        // ie. If the current line_index is 5, then the line_index
+                        // returned will be the fifth index from the start of the
+                        // desired line.
                         Anchor::Same => {
                             if offset == nlines.len() {
                                 Some((cmp::min(line_index + nlines[offset-1] + 1, last), line_index))
@@ -242,6 +268,7 @@ impl Buffer {
                             }
                         }
 
+                        // Get the index of the end of the desired line
                         Anchor::End => {
                             let end_offset = cmp::min(line_index + nlines[offset] + 1, nlines[offset]);
                             Some((end_offset, end_offset - get_line(end_offset, text).unwrap()))
@@ -257,6 +284,7 @@ impl Buffer {
                 }
             }
 
+            // The desired line is above the current line - ie moving up
             Offset::Backward(offset, from_mark) => {
                 if let Some(tuple) = self.marks.get(&from_mark) {
                     let (index, line_index) = *tuple;
@@ -265,11 +293,15 @@ impl Buffer {
                                                     .collect::<Vec<usize>>();
 
                     match anchor {
+                        // Get the index of the start of the desired line
                         Anchor::Start => {
                             let start_offset = cmp::min(line_index + nlines[offset] + 1, nlines[offset]);
                             Some((start_offset + 1, 0))
                         }
 
+                        // ie. If the current line_index is 5, then the line_index
+                        // returned will be the fifth index from the start of the
+                        // desired line.
                         Anchor::Same => {
                             if offset == 0 {
                                 Some((0, 0)) // going to start of the first line
@@ -292,6 +324,10 @@ impl Buffer {
                 }
             }
 
+            // The desired line is identified by line_number
+            //
+            // ie. Get the index of Anchor inside the 23th line in the buffer
+            // or: Get the index of the start of the 23th line
             Offset::Absolute(line_number) => {
                 let nlines = range(0, text.len()).filter(|i| text[*i] == b'\n')
                                                  .take(line_number + 1)

--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -312,7 +312,6 @@ impl Buffer {
         let text = &self.text;
         if let Some(tuple) = self.marks.get_mut(&mark) {
             let (index, line_index) = *tuple;
-            print!("{:?}", obj);
             *tuple = match obj.kind {
                 Kind::Char => {
                     match obj.offset {
@@ -365,7 +364,10 @@ impl Buffer {
                                     (end_offset, end_offset - get_line(end_offset, text).unwrap())
                                 }
 
-                                _ => (0, 0),
+                                _ => {
+                                    print!("Unhandled anchor from: {:?} ", obj);
+                                    (0, 0)
+                                },
                             }
 
                             // if offset > nlines.len() {
@@ -401,7 +403,10 @@ impl Buffer {
                                     }
                                 }
 
-                                _ => (0, 0)
+                                _ => {
+                                    print!("Unhandled anchor from: {:?} ", obj);
+                                    (0, 0)
+                                },
                             }
 
                             // if offset == nlines.len() {
@@ -438,7 +443,10 @@ impl Buffer {
                                     (end_offset, end_offset)
                                 }
 
-                                _ => (0, 0),
+                                _ => {
+                                    print!("Unhandled anchor from: {:?} ", obj);
+                                    (0, 0)
+                                },
                             }
                         }
                     }
@@ -463,7 +471,7 @@ impl Buffer {
                                 }
 
                                 _ => {
-                                    panic!("If you hit this message, please open a bug report stating how you did so!");
+                                    print!("Unhandled anchor from: {:?} ", obj);
                                     (last, last - get_line(last, text).unwrap())
                                 }
                             }
@@ -496,7 +504,10 @@ impl Buffer {
                                     }
                                 }
 
-                                _ => (0, 0),
+                                _ => {
+                                    print!("Unhandled anchor from: {:?} ", obj);
+                                    (0, 0)
+                                },
                             }
                             // if let Some(new_idx) = get_words_rev(index, offset, edger, text) {
                             //     if new_idx > 0 {
@@ -522,7 +533,10 @@ impl Buffer {
                                     (new_index, new_index - get_line(new_index, text).unwrap())
                                 }
 
-                                _ => (0, 0),
+                                _ => {
+                                    print!("Unhandled anchor from: {:?} ", obj);
+                                    (0, 0)
+                                },
                             }
                         }
                     }

--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -316,7 +316,8 @@ impl Buffer {
             *tuple = match obj.kind {
                 Kind::Char => {
                     match obj.offset {
-                        Offset::Forward(offset, _) => {
+                        // FIXME: don't ignore the from_mark here
+                        Offset::Forward(offset, from_mark) => {
                             let absolute_index = index + offset;
                             if absolute_index < last {
                                 (absolute_index, absolute_index - get_line(absolute_index, text).unwrap())
@@ -325,7 +326,8 @@ impl Buffer {
                             }
                         }
 
-                        Offset::Backward(offset, _) => {
+                        // FIXME: don't ignore the from_mark here
+                        Offset::Backward(offset, from_mark) => {
                             if index >= offset {
                                 let absolute_index = index - offset;
                                 (absolute_index, absolute_index - get_line(absolute_index, text).unwrap())
@@ -343,7 +345,8 @@ impl Buffer {
 
                 Kind::Line(anchor) => {
                     match obj.offset {
-                        Offset::Forward(offset, _) => {
+                        // FIXME: don't ignore the from_mark here
+                        Offset::Forward(offset, from_mark) => {
                             let nlines = range(index, text.len()).filter(|i| text[*i] == b'\n')
                                                                .take(offset + 1)
                                                                .collect::<Vec<usize>>();
@@ -360,7 +363,8 @@ impl Buffer {
                             }
                         }
 
-                        Offset::Backward(offset, _) => {
+                        // FIXME: don't ignore the from_mark here
+                        Offset::Backward(offset, from_mark) => {
                             let nlines = range(0, index).rev().filter(|i| text[*i] == b'\n')
                                                             .take(offset + 1)
                                                             .collect::<Vec<usize>>();
@@ -401,7 +405,8 @@ impl Buffer {
 
                 Kind::Word(anchor) => {
                     match obj.offset {
-                        Offset::Forward(offset, _) => {
+                        // FIXME: don't ignore the from_mark here
+                        Offset::Forward(offset, from_mark) => {
                             // TODO: use anchor to determine this
                             let edger = WordEdgeMatch::Whitespace;
 
@@ -416,7 +421,8 @@ impl Buffer {
                             }
                         }
 
-                        Offset::Backward(offset, _) => {
+                        // FIXME: don't ignore the from_mark here
+                        Offset::Backward(offset, from_mark) => {
                             // TODO: use anchor to determine this
                             let edger = WordEdgeMatch::Whitespace;
 

--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -562,7 +562,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_char_right() {
+    fn move_mark_char_right() {
         let mut buffer = setup_buffer("Some test content");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -577,7 +577,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_char_left() {
+    fn move_mark_char_left() {
         let mut buffer = setup_buffer("Some test content");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -593,7 +593,7 @@ mod test {
     }
     
     #[test]
-    fn move_mark_textobject_five_chars_right() {
+    fn move_mark_five_chars_right() {
         let mut buffer = setup_buffer("Some test content");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -608,7 +608,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_line_down() {
+    fn move_mark_line_down() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -623,7 +623,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_line_up() {
+    fn move_mark_line_up() {
         let mut buffer = setup_buffer("Some test content\nnew lines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -639,7 +639,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_two_lines_down() {
+    fn move_mark_two_lines_down() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -654,7 +654,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_line_down_to_shorter_line() {
+    fn move_mark_line_down_to_shorter_line() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -679,7 +679,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_two_words_right() {
+    fn move_mark_two_words_right() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -694,7 +694,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_two_words_left() {
+    fn move_mark_two_words_left() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -710,7 +710,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_move_word_left_at_start_of_buffer() {
+    fn move_mark_move_word_left_at_start_of_buffer() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -726,7 +726,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_move_word_right_past_end_of_buffer() {
+    fn move_mark_move_word_right_past_end_of_buffer() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -742,7 +742,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_second_word_in_buffer() {
+    fn move_mark_second_word_in_buffer() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -758,7 +758,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_fifth_word_in_buffer() {
+    fn move_mark_fifth_word_in_buffer() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -774,7 +774,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_second_line_in_buffer() {
+    fn move_mark_second_line_in_buffer() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -789,7 +789,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_second_char_in_buffer() {
+    fn move_mark_second_char_in_buffer() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -805,7 +805,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_end_of_line() {
+    fn move_mark_end_of_line() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -821,7 +821,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_start_of_line() {
+    fn move_mark_start_of_line() {
         let mut buffer = setup_buffer("Some test content\nwith new\nlines!");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -837,7 +837,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_past_last_line() {
+    fn move_mark_past_last_line() {
         let mut buffer = setup_buffer("Some test content\n");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -852,7 +852,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_line_up_middle_of_file() {
+    fn move_mark_line_up_middle_of_file() {
         let mut buffer = setup_buffer("Some\ntest\ncontent");
         let mark = Mark::Cursor(0);
         let obj = TextObject {
@@ -868,7 +868,7 @@ mod test {
     }
 
     #[test]
-    fn move_mark_textobject_line_up_past_first_line() {
+    fn move_mark_line_up_past_first_line() {
         let mut buffer = setup_buffer("Some\ntest\ncontent");
         let mark = Mark::Cursor(0);
         let obj = TextObject {

--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -308,116 +308,145 @@ impl Buffer {
     /// Sets the mark to the location of a given TextObject, if it exists.
     /// Adds a new mark or overwrites an existing mark.
     pub fn set_mark_to_object(&mut self, mark: Mark, obj: TextObject) {
-        // let last = self.len() - 1;
-        // let text = &self.text;
-        // if let Some(tuple) = self.marks.get_mut(&mark) {
-        //     let (index, line_index) = *tuple;
-        //     print!("{:?}", obj);
-        //     *tuple = match obj.kind {
-        //         Kind::Char => {
-        //             match obj.offset {
-        //                 Offset::Forward(offset, _) => {
-        //                     let absolute_index = index + offset;
-        //                     if absolute_index < last {
-        //                         (absolute_index, absolute_index - get_line(absolute_index, text).unwrap())
-        //                     } else {
-        //                         (last, last - get_line(last, text).unwrap())
-        //                     }
-        //                 }
+        let last = self.len() - 1;
+        let text = &self.text;
+        if let Some(tuple) = self.marks.get_mut(&mark) {
+            let (index, line_index) = *tuple;
+            print!("{:?}", obj);
+            *tuple = match obj.kind {
+                Kind::Char => {
+                    match obj.offset {
+                        Offset::Forward(offset, _) => {
+                            let absolute_index = index + offset;
+                            if absolute_index < last {
+                                (absolute_index, absolute_index - get_line(absolute_index, text).unwrap())
+                            } else {
+                                (last, last - get_line(last, text).unwrap())
+                            }
+                        }
 
-        //                 Offset::Backward(offset, _) => {
-        //                     if index >= offset {
-        //                         let absolute_index = index - offset;
-        //                         (absolute_index, absolute_index - get_line(absolute_index, text).unwrap())
-        //                     } else {
-        //                         (0, 0)
-        //                     }
-        //                 }
+                        Offset::Backward(offset, _) => {
+                            if index >= offset {
+                                let absolute_index = index - offset;
+                                (absolute_index, absolute_index - get_line(absolute_index, text).unwrap())
+                            } else {
+                                (0, 0)
+                            }
+                        }
 
-        //                 // TODO: find out the usecase for this
-        //                 Offset::Absolute(_) => (0, 0),
-        //             }
-        //         }
-
-
-        //         Kind::Line(anchor) => {
-        //             match obj.offset {
-        //                 Offset::Forward(offset, _) => {
-        //                     let nlines = range(index, text.len()).filter(|i| text[*i] == b'\n')
-        //                                                        .take(offset + 1)
-        //                                                        .collect::<Vec<usize>>();
-        //                     if offset > nlines.len() {
-        //                         (last, last - get_line(last, text).unwrap())
-        //                     } else if offset == nlines.len() {
-        //                         (cmp::min(line_index + nlines[offset-1] + 1, last), line_index)
-        //                     } else {
-        //                         (cmp::min(line_index + nlines[offset-1] + 1, nlines[offset]), line_index)
-        //                     }
-        //                 }
-
-        //                 Offset::Backward(offset, _) => {
-        //                     let nlines = range(0, index).rev().filter(|i| text[*i] == b'\n')
-        //                                                     .take(offset + 1)
-        //                                                     .collect::<Vec<usize>>();
-        //                     if offset == nlines.len() {
-        //                         (cmp::min(line_index, nlines[0]), line_index)
-        //                     } else if offset > nlines.len() {
-        //                         (0, 0)
-        //                     } else {
-        //                         (cmp::min(line_index + nlines[offset] + 1, nlines[offset-1]), line_index)
-        //                     }
-        //                 }
-
-        //                 // TODO: find out the usecase for this
-        //                 Offset::Absolute(_) => (0, 0)
-        //             }
-        //         }
+                        Offset::Absolute(absolute_char_offset) => {
+                            (absolute_char_offset, absolute_char_offset)
+                        },
+                    }
+                }
 
 
-        //         Kind::Word(anchor) => {
-        //             match obj.offset {
-        //                 Offset::Forward(offset, _) => {
-        //                     // TODO: use anchor to determine this
-        //                     let edger = WordEdgeMatch::Whitespace;
+                Kind::Line(anchor) => {
+                    match obj.offset {
+                        Offset::Forward(offset, _) => {
+                            let nlines = range(index, text.len()).filter(|i| text[*i] == b'\n')
+                                                               .take(offset + 1)
+                                                               .collect::<Vec<usize>>();
+                            if offset > nlines.len() {
+                                (last, last - get_line(last, text).unwrap())
+                            } else if offset == nlines.len() {
+                                (cmp::min(line_index + nlines[offset-1] + 1, last), line_index)
+                            } else {
+                                (cmp::min(line_index + nlines[offset-1] + 1, nlines[offset]), line_index)
+                            }
+                        }
 
-        //                     if let Some(new_idx) = get_words(index, offset, edger, text) {
-        //                         if new_idx < last {
-        //                             (new_idx, new_idx - get_line(new_idx, text).unwrap())
-        //                         } else {
-        //                             (last, last - get_line(last, text).unwrap())
-        //                         }
-        //                     } else {
-        //                         (last, last - get_line(last, text).unwrap())
-        //                     }
-        //                 }
+                        Offset::Backward(offset, _) => {
+                            let nlines = range(0, index).rev().filter(|i| text[*i] == b'\n')
+                                                            .take(offset + 1)
+                                                            .collect::<Vec<usize>>();
+                            if offset == nlines.len() {
+                                (cmp::min(line_index, nlines[0]), line_index)
+                            } else if offset > nlines.len() {
+                                (0, 0)
+                            } else {
+                                (cmp::min(line_index + nlines[offset] + 1, nlines[offset-1]), line_index)
+                            }
+                        }
 
-        //                 Offset::Backward(offset, _) => {
-        //                     // TODO: use anchor to determine this
-        //                     let edger = WordEdgeMatch::Whitespace;
+                        Offset::Absolute(line_number) => {
+                            match anchor {
+                                Anchor::Start => {
+                                    let nlines = range(0, text.len()).filter(|i| text[*i] == b'\n')
+                                                                       .take(line_number + 1)
+                                                                       .collect::<Vec<usize>>();
+                                    let end_offset = nlines[line_number - 1];
+                                    let start = get_line(end_offset, text).unwrap();
+                                    (start, 0)
+                                }
 
-        //                     if let Some(new_idx) = get_words_rev(index, offset, edger, text) {
-        //                         if new_idx > 0 {
-        //                             (new_idx, new_idx - get_line(new_idx, text).unwrap())
-        //                         } else {
-        //                             (0, 0)
-        //                         }
-        //                     } else {
-        //                         (0, 0)
-        //                     }
-        //                 }
+                                Anchor::End => {
+                                    let nlines = range(0, text.len()).filter(|i| text[*i] == b'\n')
+                                                                       .take(line_number + 1)
+                                                                       .collect::<Vec<usize>>();
+                                    let end_offset = nlines[line_number - 1];
+                                    (end_offset, end_offset)
+                                }
 
-        //                 // TODO: find out the usecase for this
-        //                 Offset::Absolute(_) => (0, 0)
-        //             }
-        //         }
+                                _ => (0, 0),
+                            }
+                        }
+                    }
+                }
 
 
-        //     }
-        // }
+                Kind::Word(anchor) => {
+                    match obj.offset {
+                        Offset::Forward(offset, _) => {
+                            // TODO: use anchor to determine this
+                            let edger = WordEdgeMatch::Whitespace;
 
-        if let Some(idx) = self.get_object_index(obj) {
-            self.set_mark(mark, idx);
+                            if let Some(new_idx) = get_words(index, offset, edger, text) {
+                                if new_idx < last {
+                                    (new_idx, new_idx - get_line(new_idx, text).unwrap())
+                                } else {
+                                    (last, last - get_line(last, text).unwrap())
+                                }
+                            } else {
+                                (last, last - get_line(last, text).unwrap())
+                            }
+                        }
+
+                        Offset::Backward(offset, _) => {
+                            // TODO: use anchor to determine this
+                            let edger = WordEdgeMatch::Whitespace;
+
+                            if let Some(new_idx) = get_words_rev(index, offset, edger, text) {
+                                if new_idx > 0 {
+                                    (new_idx, new_idx - get_line(new_idx, text).unwrap())
+                                } else {
+                                    (0, 0)
+                                }
+                            } else {
+                                (0, 0)
+                            }
+                        }
+
+                        // FIXME
+                        Offset::Absolute(word_number) => {
+                            match anchor {
+                                Anchor::Start => {
+                                    (0,0)
+                                }
+
+                                _ => (0, 0),
+                            }
+                        }
+                    }
+                }
+
+
+            }
         }
+
+        // if let Some(idx) = self.get_object_index(obj) {
+        //     self.set_mark(mark, idx);
+        // }
     }
 
     /// Sets the mark to a given absolute index. Adds a new mark or overwrites an existing mark.
@@ -823,7 +852,7 @@ mod test {
         buffer.set_mark_to_object(mark, obj);
 
         assert_eq!(buffer.marks.get(&mark).unwrap(), &(18, 0));
-        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (18, 1));
+        assert_eq!(buffer.get_mark_coords(mark).unwrap(), (0, 1));
     }
 
     #[test]

--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -200,13 +200,13 @@ impl Buffer {
 
     // Most of get_line_index and get_word_index should really be under the textobject module, with the type definitions
     fn get_line_index(&self, offset: Offset, anchor: Anchor) -> Option<usize> {
-        let (start, mut lines, reverse) = match offset {
-            Offset::Absolute(lines) => (0, lines, false),
+        let (start, mut lines, reverse, mark) = match offset {
+            Offset::Absolute(lines) => (0, lines, false, None),
             Offset::Forward(lines, mark) => if let Some(idx) = self.get_mark_idx(mark) {
-                (idx, lines, false)
+                (idx, lines, false, Some(mark))
             } else { return None; },
             Offset::Backward(lines, mark) => if let Some(idx) = self.get_mark_idx(mark) {
-                (idx, lines, true)
+                (idx, lines, true, Some(mark))
             } else { return None; },
         };
 
@@ -239,8 +239,12 @@ impl Buffer {
             match anchor {
                 Anchor::End | Anchor::Before => -1,
                 Anchor::Same => {
-                    let (current_line_offset, _) = self.get_mark_coords(Mark::Cursor(0)).unwrap();
-                    current_line_offset as i32
+                    if let Some(mark) = mark {
+                        let (current_line_offset, _) = self.get_mark_coords(mark).unwrap();
+                        current_line_offset as i32
+                    } else {
+                        0
+                    }
                 }
                 _ => 0
             }

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -61,6 +61,32 @@ pub struct Command {
     pub object: TextObject, // where to do it
 }
 
+impl Command {
+    /// Shortcut to create an ExitEditor command
+    pub fn exit_editor() -> Command {
+        Command {
+            action: Action::Instruction(Instruction::ExitEditor),
+            number: 0,
+            object: TextObject {
+                kind: Kind::Char,
+                offset: Offset::Absolute(0),
+            },
+        }
+    }
+
+    /// Shortcut to create a SaveBuffer command
+    pub fn save_buffer() -> Command {
+        Command {
+            action: Action::Instruction(Instruction::SaveBuffer),
+            number: 0,
+            object: TextObject {
+                kind: Kind::Char,
+                offset: Offset::Absolute(0),
+            },
+        }
+    }
+}
+
 pub struct Builder {
     number: Option<i32>,
     repeat: Option<usize>,

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -85,6 +85,18 @@ impl Command {
             },
         }
     }
+
+    /// Shortcut to create an Insert command
+    pub fn insert_char(c: char) -> Command {
+        Command {
+            number: 0,
+            action: Action::Operation(Operation::Insert(c)),
+            object: TextObject {
+                kind: Kind::Char,
+                offset: Offset::Absolute(0)
+            }
+        }
+    }
 }
 
 pub struct Builder {

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -1,8 +1,6 @@
-use std::default::Default;
-
 use keyboard::Key;
 use keymap::{ KeyMap, KeyMapState };
-use buffer::{ Direction, Mark, WordEdgeMatch };
+use buffer::Mark;
 use textobject::{ TextObject, Offset, Kind, Anchor };
 use overlay::OverlayType;
 

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -362,7 +362,7 @@ fn default_keymap() -> KeyMap<Partial> {
         offset: Offset::Forward(1, Mark::Cursor(0))
     }));
     keymap.bind_key(Key::Char('b'), Partial::Object(TextObject {
-        kind: Kind::Word(Anchor::End),
+        kind: Kind::Word(Anchor::Start),
         offset: Offset::Backward(1, Mark::Cursor(0))
     }));
 

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -58,7 +58,7 @@ pub enum Action {
 pub struct Command {
     pub number: i32,        // numeric paramter, line number, repeat count, etc.
     pub action: Action,     // what to do
-    pub object: TextObject, // where to do it
+    pub object: Option<TextObject>, // where to do it
 }
 
 impl Command {
@@ -67,10 +67,10 @@ impl Command {
         Command {
             action: Action::Instruction(Instruction::ExitEditor),
             number: 0,
-            object: TextObject {
+            object: Some(TextObject {
                 kind: Kind::Char,
                 offset: Offset::Absolute(0),
-            },
+            }),
         }
     }
 
@@ -79,10 +79,10 @@ impl Command {
         Command {
             action: Action::Instruction(Instruction::SaveBuffer),
             number: 0,
-            object: TextObject {
+            object: Some(TextObject {
                 kind: Kind::Char,
                 offset: Offset::Absolute(0),
-            },
+            }),
         }
     }
 
@@ -91,10 +91,10 @@ impl Command {
         Command {
             number: 1,
             action: Action::Operation(Operation::Insert(c)),
-            object: TextObject {
+            object: Some(TextObject {
                 kind: Kind::Char,
                 offset: Offset::Absolute(0)
-            }
+            })
         }
     }
 
@@ -104,10 +104,10 @@ impl Command {
         Command {
             number: 4,
             action: Action::Operation(Operation::Insert(' ')),
-            object: TextObject {
+            object: Some(TextObject {
                 kind: Kind::Char,
                 offset: Offset::Absolute(0)
-            }
+            })
         }
     }
 }
@@ -239,7 +239,7 @@ impl Builder {
             return Some(Command {
                 number: self.repeat.unwrap_or(0) as i32,
                 action: Action::Instruction(i),
-                object: self.complete_object().unwrap_or_default()
+                object: self.complete_object()
             });
         }
 
@@ -249,14 +249,14 @@ impl Builder {
                 return Some(Command {
                     number: self.repeat.unwrap_or(0) as i32,
                     action: Action::Operation(o),
-                    object: to
+                    object: Some(to)
                 });
             } else {
                 // we have just an object, assume move cursor instruction
                 return Some(Command {
                     number: self.repeat.unwrap_or(0) as i32,
                     action: Action::Instruction(Instruction::SetMark(Mark::Cursor(0))),
-                    object: to
+                    object: Some(to)
                 });
             }
         }

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -67,10 +67,7 @@ impl Command {
         Command {
             action: Action::Instruction(Instruction::ExitEditor),
             number: 0,
-            object: Some(TextObject {
-                kind: Kind::Char,
-                offset: Offset::Absolute(0),
-            }),
+            object: None,
         }
     }
 
@@ -79,10 +76,7 @@ impl Command {
         Command {
             action: Action::Instruction(Instruction::SaveBuffer),
             number: 0,
-            object: Some(TextObject {
-                kind: Kind::Char,
-                offset: Offset::Absolute(0),
-            }),
+            object: None,
         }
     }
 
@@ -91,10 +85,7 @@ impl Command {
         Command {
             number: 1,
             action: Action::Operation(Operation::Insert(c)),
-            object: Some(TextObject {
-                kind: Kind::Char,
-                offset: Offset::Absolute(0)
-            })
+            object: None,
         }
     }
 
@@ -104,10 +95,7 @@ impl Command {
         Command {
             number: 4,
             action: Action::Operation(Operation::Insert(' ')),
-            object: Some(TextObject {
-                kind: Kind::Char,
-                offset: Offset::Absolute(0)
-            })
+            object: None,
         }
     }
 }
@@ -237,7 +225,7 @@ impl Builder {
         // editor instructions may not need a text object, go ahead and return immediately
         if let Some(Action::Instruction(i)) = self.action {
             return Some(Command {
-                number: self.repeat.unwrap_or(0) as i32,
+                number: self.repeat.unwrap_or(1) as i32,
                 action: Action::Instruction(i),
                 object: self.complete_object()
             });
@@ -247,14 +235,14 @@ impl Builder {
             if let Some(Action::Operation(o)) = self.action {
                 // we have an object, and an operation
                 return Some(Command {
-                    number: self.repeat.unwrap_or(0) as i32,
+                    number: self.repeat.unwrap_or(1) as i32,
                     action: Action::Operation(o),
                     object: Some(to)
                 });
             } else {
                 // we have just an object, assume move cursor instruction
                 return Some(Command {
-                    number: self.repeat.unwrap_or(0) as i32,
+                    number: self.repeat.unwrap_or(1) as i32,
                     action: Action::Instruction(Instruction::SetMark(Mark::Cursor(0))),
                     object: Some(to)
                 });

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -89,8 +89,21 @@ impl Command {
     /// Shortcut to create an Insert command
     pub fn insert_char(c: char) -> Command {
         Command {
-            number: 0,
+            number: 1,
             action: Action::Operation(Operation::Insert(c)),
+            object: TextObject {
+                kind: Kind::Char,
+                offset: Offset::Absolute(0)
+            }
+        }
+    }
+
+    /// Shortcut to create an Insert command
+    // FIXME: shouldn't need this method
+    pub fn insert_tab() -> Command {
+        Command {
+            number: 4,
+            action: Action::Operation(Operation::Insert(' ')),
             object: TextObject {
                 kind: Kind::Char,
                 offset: Offset::Absolute(0)

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -354,7 +354,7 @@ fn default_keymap() -> KeyMap<Partial> {
         kind: Kind::Line(Anchor::End),
         offset: Offset::Forward(1, Mark::Cursor(0)),
     }));
-    keymap.bind_key(Key::Char('^'), Partial::Object(TextObject {
+    keymap.bind_key(Key::Char('0'), Partial::Object(TextObject {
         kind: Kind::Line(Anchor::Start),
         offset: Offset::Forward(1, Mark::Cursor(0)),
     }));

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -28,11 +28,11 @@ pub enum Instruction {
 #[derive(Copy, Debug)]
 #[allow(dead_code)]
 pub enum Operation {
-    Insert,     // insert text
-    Delete,     // delete some object
+    Insert(char), // insert text
+    Delete,       // delete some object
 
-    Undo,       // rewind buffer transaction log
-    Redo,       // replay buffer transaction log
+    Undo,         // rewind buffer transaction log
+    Redo,         // replay buffer transaction log
 }
 
 /// Fragments that can be combined to specify a command

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -336,6 +336,16 @@ fn default_keymap() -> KeyMap<Partial> {
         offset: Offset::Backward(1, Mark::Cursor(0))
     }));
 
+    // start/end line
+    keymap.bind_key(Key::Char('$'), Partial::Object(TextObject {
+        kind: Kind::Line(Anchor::End),
+        offset: Offset::Forward(1, Mark::Cursor(0)),
+    }));
+    keymap.bind_key(Key::Char('^'), Partial::Object(TextObject {
+        kind: Kind::Line(Anchor::Start),
+        offset: Offset::Forward(1, Mark::Cursor(0)),
+    }));
+
     // kinds
     keymap.bind_keys(&[Key::Char('`'), Key::Char('c')], Partial::Kind(Kind::Char));
     keymap.bind_keys(&[Key::Char('`'), Key::Char('w')], Partial::Kind(Kind::Word(Anchor::Before)));

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -98,6 +98,24 @@ impl Command {
             object: None,
         }
     }
+
+    /// Shortcut to create Undo command
+    pub fn undo() -> Command {
+        Command {
+            number: 1,
+            action: Action::Operation(Operation::Undo),
+            object: None
+        }
+    }
+
+    /// Shortcut to create Redo command
+    pub fn redo() -> Command {
+        Command {
+            number: 1,
+            action: Action::Operation(Operation::Redo),
+            object: None
+        }
+    }
 }
 
 pub struct Builder {

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -8,7 +8,7 @@ use overlay::OverlayType;
 
 /// Instructions for the Editor.
 /// These do NOT alter the text, but may change editor/view state
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 #[allow(dead_code)]
 pub enum Instruction {
     SaveBuffer,
@@ -25,7 +25,7 @@ pub enum Instruction {
 /// Note that these differ from log::Change in that they are higher-level
 /// operations dependent on state (cursor/mark locations, etc.), as opposed
 /// to concrete operations on absolute indexes (insert 'a' at index 158, etc.)
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 #[allow(dead_code)]
 pub enum Operation {
     Insert,     // insert text
@@ -36,7 +36,7 @@ pub enum Operation {
 }
 
 /// Fragments that can be combined to specify a command
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 #[allow(dead_code)]
 pub enum Partial {
     Kind(Kind),
@@ -46,7 +46,7 @@ pub enum Partial {
     Action(Action),
 }
 
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 #[allow(dead_code)]
 pub enum Action {
     Operation(Operation),
@@ -54,7 +54,7 @@ pub enum Action {
 }
 
 /// A complete, actionable command
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 pub struct Command {
     pub number: i32,        // numeric paramter, line number, repeat count, etc.
     pub action: Action,     // what to do
@@ -76,7 +76,7 @@ pub struct Builder {
     keymap: KeyMap<Partial>,
 }
 
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 pub enum BuilderEvent {
     Invalid,            // cannot find a valid interpretation
     Incomplete,         // needs more information

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -115,6 +115,18 @@ impl Command {
             object: None
         }
     }
+
+    pub fn movement(offset: Offset, kind: Kind) -> Command {
+        Command {
+            number: 1,
+            action: Action::Instruction(Instruction::SetMark(Mark::Cursor(0))),
+            object: Some(TextObject {
+                kind: kind,
+                offset: offset
+            })
+        }
+
+    }
 }
 
 pub struct Builder {

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -173,7 +173,7 @@ impl Builder {
             if c.is_digit(10) && (self.reading_number || c != '0') {
                 let n = c.to_digit(10).unwrap();
                 self.reading_number = true;
-                self.append_digit(n);
+                self.append_digit(n as i32);
                 return BuilderEvent::Incomplete;
             } else if self.reading_number {
                 
@@ -268,11 +268,11 @@ impl Builder {
         None
     }
 
-    fn append_digit(&mut self, n: usize) {
+    fn append_digit(&mut self, n: i32) {
         if let Some(current) = self.number {
-            self.number = Some((current*10) + n as i32);
+            self.number = Some((current*10) + n);
         } else {
-            self.number = Some(n as i32);
+            self.number = Some(n);
         }
     }
 

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -165,13 +165,6 @@ impl<'e, T: Frontend> Editor<'e, T> {
             Action::Instruction(i) => self.handle_instruction(i, command),
             Action::Operation(o) => self.handle_operation(o, command),
         }
-
-        // TODO: re-implement these with the command/builder system
-        // match command {
-        //     Command::LineEnd            => self.view.move_cursor_to_line_end(),
-        //     Command::LineStart          => self.view.move_cursor_to_line_start(),
-        //     Command::InsertTab          => self.view.insert_tab(),
-        // }
     }
 
 

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -234,7 +234,7 @@ impl<'e, T: Frontend> Editor<'e, T> {
 
     fn handle_operation(&mut self, operation: Operation, command: Cmd) {
         match operation {
-            Operation::Insert => {}
+            Operation::Insert(c) => { self.view.insert_char(c) }
             Operation::Delete => {
                 // FIXME: update to delete lines
                 let obj = command.object;

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -4,13 +4,11 @@ use keyboard::Key;
 use view::View;
 use frontends::{Frontend, EditorEvent};
 use modes::Mode;
-use overlay::{Overlay, OverlayType, OverlayEvent};
+use overlay::{Overlay, OverlayEvent};
 
 use command::Command as Cmd;
 use command::{Action, BuilderEvent, Operation, Instruction};
-use textobject::{Anchor, TextObject, Kind, Offset};
-
-use buffer::WordEdgeMatch;
+use textobject::Offset;
 
 
 #[derive(Copy, Debug, PartialEq, Eq)]
@@ -18,21 +16,7 @@ pub enum Command {
     SaveBuffer,
     ExitEditor,
 
-    MoveCursor(Direction, usize),
-    LineEnd,
-    LineStart,
-
-    Delete(Direction, usize),
-    InsertTab,
-    InsertChar(char),
-
-    SetOverlay(OverlayType),
-
-    Undo,
-    Redo,
-
     Unknown,
-    None,
 }
 
 impl Command {
@@ -176,7 +160,7 @@ impl<'e, T: Frontend> Editor<'e, T> {
             Instruction::ExitEditor => { self.running = false; }
             Instruction::SetMark(mark) => {
                 if let Some(object) = command.object {
-                    self.view.move_mark(object, command.number as usize)
+                    self.view.move_mark(mark, object, command.number as usize)
                 }
             }
             Instruction::SetOverlay(overlay_type) => {

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -248,8 +248,8 @@ impl<'e, T: Frontend> Editor<'e, T> {
 
                 self.view.delete_chars(dir, n) 
             }
-            Operation::Undo => {}
-            Operation::Redo => {}
+            Operation::Undo => { self.view.undo() }
+            Operation::Redo => { self.view.redo() }
         }
     }
 

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -129,14 +129,7 @@ impl<'e, T: Frontend> Editor<'e, T> {
                     Overlay::Prompt { .. } => {
                         match Command::from_str(&*data) {
                             Command::ExitEditor => {
-                                return BuilderEvent::Complete(Cmd {
-                                    action:Action::Instruction(Instruction::ExitEditor),
-                                    number: 0,
-                                    object: TextObject {
-                                        kind: Kind::Char,
-                                        offset: Offset::Absolute(0),
-                                    },
-                                })
+                                return BuilderEvent::Complete(Cmd::exit_editor())
                             }
                             _ => BuilderEvent::Incomplete
                         }
@@ -146,14 +139,7 @@ impl<'e, T: Frontend> Editor<'e, T> {
                         let path = Path::new(&*data);
                         self.view.buffer.file_path = Some(path);
                         // Command::SaveBuffer
-                        BuilderEvent::Complete(Cmd {
-                            action:Action::Instruction(Instruction::SaveBuffer),
-                            number: 0,
-                            object: TextObject {
-                                kind: Kind::Char,
-                                offset: Offset::Absolute(0),
-                            },
-                        })
+                        BuilderEvent::Complete(Cmd::save_buffer())
                     }
                     _ => BuilderEvent::Incomplete,
                 }

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -174,12 +174,12 @@ impl<'e, T: Frontend> Editor<'e, T> {
             Instruction::ExitEditor => { self.running = false; }
             Instruction::SetMark(mark) => {
                 if let Some(object) = command.object {
-                    let (mut dir, n) = match object.offset {
-                        Offset::Backward(n, _) => (Direction::Left, n),
-                        Offset::Forward(n, _) => (Direction::Right, n),
+                    let mut dir = match object.offset {
+                        Offset::Backward(_, _) => Direction::Left,
+                        Offset::Forward(_, _) => Direction::Right,
 
                         // FIXME
-                        Offset::Absolute(n) => (Direction::Right, 0)
+                        Offset::Absolute(_) => Direction::Right
                     };
 
                     if let Kind::Line(anchor) = object.kind {
@@ -197,7 +197,7 @@ impl<'e, T: Frontend> Editor<'e, T> {
                     }
 
 
-                    self.view.move_cursor(dir, n)
+                    self.view.move_cursor(dir, command.number as usize)
                 }
             }
             Instruction::SetOverlay(overlay_type) => {
@@ -216,14 +216,14 @@ impl<'e, T: Frontend> Editor<'e, T> {
             Operation::Delete => {
                 // FIXME: update to delete lines
                 if let Some(obj) = command.object {
-                    let (dir, n) = match obj.offset {
-                        Offset::Forward(n, _) => (Direction::Right, n),
-                        Offset::Backward(n, _) => (Direction::Left, n),
+                    let dir = match obj.offset {
+                        Offset::Forward(_, _) => Direction::Right,
+                        Offset::Backward(_, _) => Direction::Left,
 
-                        Offset::Absolute(n) => (Direction::Right, 0),
+                        Offset::Absolute(_) => Direction::Right,
                     };
 
-                    self.view.delete_chars(dir, n) 
+                    self.view.delete_chars(dir, command.number as usize)
                 }
             }
             Operation::Undo => { self.view.undo() }

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -8,8 +8,7 @@ use overlay::{Overlay, OverlayType, OverlayEvent};
 
 use command::Command as Cmd;
 use command::{Action, BuilderEvent, Operation, Instruction};
-
-use textobject::{TextObject, Kind, Offset};
+use textobject::{Anchor, TextObject, Kind, Offset};
 
 
 #[derive(Copy, Debug, PartialEq, Eq)]
@@ -189,13 +188,20 @@ impl<'e, T: Frontend> Editor<'e, T> {
                     Offset::Absolute(n) => (Direction::Right, 0)
                 };
 
-                if let Kind::Line(_) = command.object.kind {
+                if let Kind::Line(anchor) = command.object.kind {
                     if dir == Direction::Left {
                         dir = Direction::Up
                     } else {
                         dir = Direction::Down
                     }
+
+                    match anchor {
+                        Anchor::End => { return self.view.move_cursor_to_line_end() }
+                        Anchor::Start => { return self.view.move_cursor_to_line_start() }
+                        _ => {}
+                    }
                 }
+
 
                 self.view.move_cursor(dir, n)
             }

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -1,5 +1,4 @@
 use input::Input;
-use buffer::Direction;
 use keyboard::Key;
 use view::View;
 use frontends::{Frontend, EditorEvent};
@@ -165,7 +164,7 @@ impl<'e, T: Frontend> Editor<'e, T> {
             Instruction::ExitEditor => { self.running = false; }
             Instruction::SetMark(mark) => {
                 if let Some(object) = command.object {
-                    self.view.move_mark(mark, object, command.number as usize)
+                    self.view.move_mark(mark, object)
                 }
             }
             Instruction::SetOverlay(overlay_type) => {

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -213,7 +213,11 @@ impl<'e, T: Frontend> Editor<'e, T> {
 
     fn handle_operation(&mut self, operation: Operation, command: Cmd) {
         match operation {
-            Operation::Insert(c) => { self.view.insert_char(c) }
+            Operation::Insert(c) => {
+                for _ in 0..command.number {
+                    self.view.insert_char(c)
+                }
+            }
             Operation::Delete => {
                 // FIXME: update to delete lines
                 let obj = command.object;

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -181,24 +181,11 @@ impl<'e, T: Frontend> Editor<'e, T> {
             Action::Operation(o) => self.handle_operation(o, command),
         }
 
+        // TODO: re-implement these with the command/builder system
         // match command {
-        //     // Editor Commands
-        //     Command::SaveBuffer         => self.view.try_save_buffer(),
-        //     Command::SetOverlay(o)      => self.view.set_overlay(o),
-
-        //     // Navigation
-        //     Command::MoveCursor(dir, n) => self.view.move_cursor(dir, n),
         //     Command::LineEnd            => self.view.move_cursor_to_line_end(),
         //     Command::LineStart          => self.view.move_cursor_to_line_start(),
-
-        //     // Editing
-        //     Command::Delete(dir, n)     => self.view.delete_chars(dir, n),
         //     Command::InsertTab          => self.view.insert_tab(),
-        //     Command::InsertChar(c)      => self.view.insert_char(c),
-        //     Command::Redo               => self.view.redo(),
-        //     Command::Undo               => self.view.undo(),
-
-        //     _ => {},
         // }
     }
 

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -176,47 +176,7 @@ impl<'e, T: Frontend> Editor<'e, T> {
             Instruction::ExitEditor => { self.running = false; }
             Instruction::SetMark(mark) => {
                 if let Some(object) = command.object {
-                    // TODO: move all this to buffer
-                    //       Buffer should take the entire command and do stuff with it.
-                    //       eg:
-                    //
-                    //           self.view.move_cursor(object, command.number)
-                    //
-                    let mut dir = match object.offset {
-                        Offset::Backward(_, _) => Direction::Left,
-                        Offset::Forward(_, _) => Direction::Right,
-
-                        // FIXME
-                        Offset::Absolute(_) => Direction::Right
-                    };
-
-                    match object.kind {
-                        Kind::Line(anchor) => {
-                            if dir == Direction::Left {
-                                dir = Direction::Up
-                            } else {
-                                dir = Direction::Down
-                            }
-
-                            match anchor {
-                                Anchor::End => { return self.view.move_cursor_to_line_end() }
-                                Anchor::Start => { return self.view.move_cursor_to_line_start() }
-                                _ => {}
-                            }
-                        }
-                        Kind::Word(_) => {
-                            if let Offset::Forward(_, _) = object.offset {
-                                dir = Direction::RightWord(WordEdgeMatch::Alphabet)
-                            } else {
-                                dir = Direction::LeftWord(WordEdgeMatch::Alphabet)
-                            }
-                        }
-
-                        _ => {}
-                    }
-
-
-                    self.view.move_cursor(dir, command.number as usize)
+                    self.view.move_mark(object, command.number as usize)
                 }
             }
             Instruction::SetOverlay(overlay_type) => {

--- a/src/iota/keyboard.rs
+++ b/src/iota/keyboard.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, PartialEq, Eq, Hash, Show)]
+#[derive(Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Key {
     Tab,
     Enter,

--- a/src/iota/lib.rs
+++ b/src/iota/lib.rs
@@ -6,13 +6,11 @@
 
 #![feature(unboxed_closures)]
 #![feature(unsafe_destructor)]
-#![feature(slicing_syntax)]
 #![feature(collections)]
+#![feature(old_path)]
 #![feature(unicode)]
+#![feature(old_io)]
 #![feature(core)]
-#![feature(path)]
-#![feature(hash)]
-#![feature(io)]
 
 #![warn(missing_docs)]
 

--- a/src/iota/modes/mod.rs
+++ b/src/iota/modes/mod.rs
@@ -2,7 +2,6 @@ pub use super::keyboard::Key;
 pub use super::keymap::KeyMap;
 pub use super::editor::Command;
 pub use super::keymap::KeyMapState;
-pub use super::buffer::Direction;
 pub use super::buffer::WordEdgeMatch;
 pub use super::overlay::{Overlay, OverlayType, OverlayEvent};
 

--- a/src/iota/modes/mod.rs
+++ b/src/iota/modes/mod.rs
@@ -1,14 +1,8 @@
-pub use super::keyboard::Key;
-pub use super::keymap::KeyMap;
-pub use super::editor::Command;
-pub use super::keymap::KeyMapState;
-pub use super::buffer::WordEdgeMatch;
-pub use super::overlay::{Overlay, OverlayType, OverlayEvent};
+use keyboard::Key;
+use command::BuilderEvent;
 
 pub use self::standard::StandardMode;
 pub use self::normal::NormalMode;
-
-use command;
 
 mod standard;
 mod normal;
@@ -19,6 +13,6 @@ mod normal;
 /// A mode is a mechanism for interpreting key events and converting them into
 /// commands which the Editor will interpret.
 pub trait Mode {
-    /// Given a Key, return a Command for the Editor to interpret
-    fn handle_key_event(&mut self, key: Key) -> command::BuilderEvent;
+    /// Given a Key, return a Command wrapped in a BuilderEvent for the Editor to interpret
+    fn handle_key_event(&mut self, key: Key) -> BuilderEvent;
 }

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -70,7 +70,11 @@ impl NormalMode {
 impl Mode for NormalMode {
     /// Given a key, pass it through the NormalMode KeyMap and return the associated Command, if any.
     fn handle_key_event(&mut self, key: Key) -> command::BuilderEvent {
-        self.builder.check_key(key)
+        let result = self.builder.check_key(key);
+
+        print!("{:?}", result);
+
+        result
     }
 }
 

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -70,11 +70,7 @@ impl NormalMode {
 impl Mode for NormalMode {
     /// Given a key, pass it through the NormalMode KeyMap and return the associated Command, if any.
     fn handle_key_event(&mut self, key: Key) -> command::BuilderEvent {
-        let result = self.builder.check_key(key);
-
-        print!("{:?}", result);
-
-        result
+        self.builder.check_key(key)
     }
 }
 

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -3,9 +3,6 @@ use super::KeyMap;
 use super::Key;
 use super::Command;
 use super::KeyMapState;
-use super::Direction;
-use super::WordEdgeMatch;
-use super::OverlayType;
 
 use command;
 

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -45,8 +45,17 @@ impl NormalMode {
         keymap.bind_keys(&[Key::Char('d'), Key::Char('b')], Command::Delete(Direction::LeftWord(WordEdgeMatch::Alphabet), 1));
         keymap.bind_key(Key::Char('x'), Command::Delete(Direction::Right, 1));
         keymap.bind_key(Key::Char('X'), Command::Delete(Direction::Left, 1));
-        keymap.bind_key(Key::Char('u'), Command::Undo);
-        keymap.bind_key(Key::Ctrl('r'), Command::Redo);
+
+        keymap.bind_key(Key::Char('u'), Command {
+            number: 1,
+            action: Action::Operation(Operation::Undo),
+            object: None
+        });
+        keymap.bind_key(Key::Ctrl('r'), Command {
+            number: 1,
+            action: Action::Operation(Operation::Redo),
+            object: None
+        });
 
         keymap
     }

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -55,10 +55,12 @@ impl NormalMode {
 }
 
 impl Mode for NormalMode {
-    /// Given a key, pass it through the NormalMode KeyMap and return the associated Command, if any.
     fn handle_key_event(&mut self, key: Key) -> command::BuilderEvent {
         match self.builder.check_key(key) {
+            // builder gives us a full command, return that
             command::BuilderEvent::Complete(cmd) => command::BuilderEvent::Complete(cmd),
+
+            // no command from the builder, check the internal keymap
             command::BuilderEvent::Incomplete => {
                 if let KeyMapState::Match(c) = self.keymap.check_key(key) {
                     command::BuilderEvent::Complete(c)
@@ -66,6 +68,8 @@ impl Mode for NormalMode {
                     command::BuilderEvent::Incomplete
                 }
             }
+
+            // invalid result from builder, return invalid
             command::BuilderEvent::Invalid => { command::BuilderEvent::Invalid }
         }
     }

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -31,23 +31,12 @@ impl NormalMode {
         let mut keymap = KeyMap::new();
 
         // movement
-        keymap.bind_key(Key::Up, Command::MoveCursor(Direction::Up, 1));
-        keymap.bind_key(Key::Down, Command::MoveCursor(Direction::Down, 1));
-        keymap.bind_key(Key::Left, Command::MoveCursor(Direction::Left, 1));
-        keymap.bind_key(Key::Right, Command::MoveCursor(Direction::Right, 1));
-        keymap.bind_key(Key::Char('h'), Command::MoveCursor(Direction::Left, 1));
-        keymap.bind_key(Key::Char('j'), Command::MoveCursor(Direction::Down, 1));
-        keymap.bind_key(Key::Char('k'), Command::MoveCursor(Direction::Up, 1));
-        keymap.bind_key(Key::Char('l'), Command::MoveCursor(Direction::Right, 1));
         keymap.bind_key(Key::Char('W'), Command::MoveCursor(Direction::RightWord(WordEdgeMatch::Whitespace), 1));
         keymap.bind_key(Key::Char('B'), Command::MoveCursor(Direction::LeftWord(WordEdgeMatch::Whitespace), 1));
         keymap.bind_key(Key::Char('w'), Command::MoveCursor(Direction::RightWord(WordEdgeMatch::Alphabet), 1));
         keymap.bind_key(Key::Char('b'), Command::MoveCursor(Direction::LeftWord(WordEdgeMatch::Alphabet), 1));
         keymap.bind_key(Key::Char('G'), Command::MoveCursor(Direction::LastLine, 0));
         keymap.bind_keys(&[Key::Char('g'), Key::Char('g')], Command::MoveCursor(Direction::FirstLine, 0));
-
-        keymap.bind_key(Key::Char('0'), Command::LineStart);
-        keymap.bind_key(Key::Char('$'), Command::LineEnd);
 
         // editing
         keymap.bind_keys(&[Key::Char('d'), Key::Char('W')], Command::Delete(Direction::RightWord(WordEdgeMatch::Whitespace), 1));
@@ -58,9 +47,6 @@ impl NormalMode {
         keymap.bind_key(Key::Char('X'), Command::Delete(Direction::Left, 1));
         keymap.bind_key(Key::Char('u'), Command::Undo);
         keymap.bind_key(Key::Ctrl('r'), Command::Redo);
-
-        // open a prompt to the user
-        keymap.bind_key(Key::Char(':'), Command::SetOverlay(OverlayType::Prompt));
 
         keymap
     }

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -31,6 +31,14 @@ impl NormalMode {
         keymap
     }
 
+    fn check_keymap(&mut self, key: Key) -> BuilderEvent {
+        if let KeyMapState::Match(c) = self.keymap.check_key(key) {
+            BuilderEvent::Complete(c)
+        } else {
+            BuilderEvent::Incomplete
+        }
+    }
+
 }
 
 impl Mode for NormalMode {
@@ -40,16 +48,19 @@ impl Mode for NormalMode {
             BuilderEvent::Complete(cmd) => BuilderEvent::Complete(cmd),
 
             // no command from the builder, check the internal keymap
-            BuilderEvent::Incomplete => {
-                if let KeyMapState::Match(c) = self.keymap.check_key(key) {
-                    BuilderEvent::Complete(c)
+            BuilderEvent::Incomplete => { self.check_keymap(key) }
+
+            // invalid result from builder, return invalid if the internal
+            // keymap doesn't give a match
+            BuilderEvent::Invalid => {
+                let val = self.check_keymap(key);
+
+                if let BuilderEvent::Incomplete = val {
+                    BuilderEvent::Invalid 
                 } else {
-                    BuilderEvent::Incomplete
+                    val
                 }
             }
-
-            // invalid result from builder, return invalid
-            BuilderEvent::Invalid => { BuilderEvent::Invalid }
         }
     }
 }

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -33,8 +33,6 @@ impl NormalMode {
         // movement
         // keymap.bind_key(Key::Char('W'), Command::MoveCursor(Direction::RightWord(WordEdgeMatch::Whitespace), 1));
         // keymap.bind_key(Key::Char('B'), Command::MoveCursor(Direction::LeftWord(WordEdgeMatch::Whitespace), 1));
-        // keymap.bind_key(Key::Char('w'), Command::MoveCursor(Direction::RightWord(WordEdgeMatch::Alphabet), 1));
-        // keymap.bind_key(Key::Char('b'), Command::MoveCursor(Direction::LeftWord(WordEdgeMatch::Alphabet), 1));
         // keymap.bind_key(Key::Char('G'), Command::MoveCursor(Direction::LastLine, 0));
         // keymap.bind_keys(&[Key::Char('g'), Key::Char('g')], Command::MoveCursor(Direction::FirstLine, 0));
 

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -73,26 +73,3 @@ impl Mode for NormalMode {
         self.builder.check_key(key)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use editor::Command;
-    use buffer::Direction;
-    use keyboard::Key;
-    use modes::Mode;
-    use super::*;
-
-    fn expect_key_command(k: Key, c: Command) {
-        let mut mode: Box<Mode> = Box::new(NormalMode::new());
-        let command = mode.handle_key_event(k);
-        assert_eq!(command, c)
-    }
-
-    #[test]
-    fn test_movement_keybindings() {
-        expect_key_command(Key::Char('h'), Command::MoveCursor(Direction::Left, 1));
-        expect_key_command(Key::Char('j'), Command::MoveCursor(Direction::Down, 1));
-        expect_key_command(Key::Char('k'), Command::MoveCursor(Direction::Up, 1));
-        expect_key_command(Key::Char('l'), Command::MoveCursor(Direction::Right, 1));
-    }
-}

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -1,16 +1,14 @@
-use super::Mode;
-use super::KeyMap;
-use super::Key;
-use super::Command;
-use super::KeyMapState;
+use keyboard::Key;
+use keymap::{KeyMap, KeyMapState};
+use command::{Builder, BuilderEvent, Command};
 
-use command;
+use super::Mode;
 
 
 /// NormalMode mimics Vi's Normal mode.
 pub struct NormalMode {
-    keymap: KeyMap<command::Command>,
-    builder: command::Builder,
+    keymap: KeyMap<Command>,
+    builder: Builder,
 }
 
 impl NormalMode {
@@ -19,30 +17,16 @@ impl NormalMode {
     pub fn new() -> NormalMode {
         NormalMode {
             keymap: NormalMode::key_defaults(),
-            builder: command::Builder::new(),
+            builder: Builder::new(),
         }
     }
 
     /// Creates a KeyMap with default NormalMode key bindings
-    fn key_defaults() -> KeyMap<command::Command> {
+    fn key_defaults() -> KeyMap<Command> {
         let mut keymap = KeyMap::new();
 
-        // movement
-        // keymap.bind_key(Key::Char('W'), Command::MoveCursor(Direction::RightWord(WordEdgeMatch::Whitespace), 1));
-        // keymap.bind_key(Key::Char('B'), Command::MoveCursor(Direction::LeftWord(WordEdgeMatch::Whitespace), 1));
-        // keymap.bind_key(Key::Char('G'), Command::MoveCursor(Direction::LastLine, 0));
-        // keymap.bind_keys(&[Key::Char('g'), Key::Char('g')], Command::MoveCursor(Direction::FirstLine, 0));
-
-        // editing
-        // keymap.bind_keys(&[Key::Char('d'), Key::Char('W')], Command::Delete(Direction::RightWord(WordEdgeMatch::Whitespace), 1));
-        // keymap.bind_keys(&[Key::Char('d'), Key::Char('B')], Command::Delete(Direction::LeftWord(WordEdgeMatch::Whitespace), 1));
-        // keymap.bind_keys(&[Key::Char('d'), Key::Char('w')], Command::Delete(Direction::RightWord(WordEdgeMatch::Alphabet), 1));
-        // keymap.bind_keys(&[Key::Char('d'), Key::Char('b')], Command::Delete(Direction::LeftWord(WordEdgeMatch::Alphabet), 1));
-        // keymap.bind_key(Key::Char('x'), Command::Delete(Direction::Right, 1));
-        // keymap.bind_key(Key::Char('X'), Command::Delete(Direction::Left, 1));
-
-        keymap.bind_key(Key::Char('u'), command::Command::undo());
-        keymap.bind_key(Key::Ctrl('r'), command::Command::redo());
+        keymap.bind_key(Key::Char('u'), Command::undo());
+        keymap.bind_key(Key::Ctrl('r'), Command::redo());
 
         keymap
     }
@@ -50,22 +34,22 @@ impl NormalMode {
 }
 
 impl Mode for NormalMode {
-    fn handle_key_event(&mut self, key: Key) -> command::BuilderEvent {
+    fn handle_key_event(&mut self, key: Key) -> BuilderEvent {
         match self.builder.check_key(key) {
             // builder gives us a full command, return that
-            command::BuilderEvent::Complete(cmd) => command::BuilderEvent::Complete(cmd),
+            BuilderEvent::Complete(cmd) => BuilderEvent::Complete(cmd),
 
             // no command from the builder, check the internal keymap
-            command::BuilderEvent::Incomplete => {
+            BuilderEvent::Incomplete => {
                 if let KeyMapState::Match(c) = self.keymap.check_key(key) {
-                    command::BuilderEvent::Complete(c)
+                    BuilderEvent::Complete(c)
                 } else {
-                    command::BuilderEvent::Incomplete
+                    BuilderEvent::Incomplete
                 }
             }
 
             // invalid result from builder, return invalid
-            command::BuilderEvent::Invalid => { command::BuilderEvent::Invalid }
+            BuilderEvent::Invalid => { BuilderEvent::Invalid }
         }
     }
 }

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -12,7 +12,7 @@ use command;
 
 /// NormalMode mimics Vi's Normal mode.
 pub struct NormalMode {
-    keymap: KeyMap<Command>,
+    keymap: KeyMap<command::Command>,
     builder: command::Builder,
 }
 
@@ -27,35 +27,27 @@ impl NormalMode {
     }
 
     /// Creates a KeyMap with default NormalMode key bindings
-    fn key_defaults() -> KeyMap<Command> {
+    fn key_defaults() -> KeyMap<command::Command> {
         let mut keymap = KeyMap::new();
 
         // movement
-        keymap.bind_key(Key::Char('W'), Command::MoveCursor(Direction::RightWord(WordEdgeMatch::Whitespace), 1));
-        keymap.bind_key(Key::Char('B'), Command::MoveCursor(Direction::LeftWord(WordEdgeMatch::Whitespace), 1));
-        keymap.bind_key(Key::Char('w'), Command::MoveCursor(Direction::RightWord(WordEdgeMatch::Alphabet), 1));
-        keymap.bind_key(Key::Char('b'), Command::MoveCursor(Direction::LeftWord(WordEdgeMatch::Alphabet), 1));
-        keymap.bind_key(Key::Char('G'), Command::MoveCursor(Direction::LastLine, 0));
-        keymap.bind_keys(&[Key::Char('g'), Key::Char('g')], Command::MoveCursor(Direction::FirstLine, 0));
+        // keymap.bind_key(Key::Char('W'), Command::MoveCursor(Direction::RightWord(WordEdgeMatch::Whitespace), 1));
+        // keymap.bind_key(Key::Char('B'), Command::MoveCursor(Direction::LeftWord(WordEdgeMatch::Whitespace), 1));
+        // keymap.bind_key(Key::Char('w'), Command::MoveCursor(Direction::RightWord(WordEdgeMatch::Alphabet), 1));
+        // keymap.bind_key(Key::Char('b'), Command::MoveCursor(Direction::LeftWord(WordEdgeMatch::Alphabet), 1));
+        // keymap.bind_key(Key::Char('G'), Command::MoveCursor(Direction::LastLine, 0));
+        // keymap.bind_keys(&[Key::Char('g'), Key::Char('g')], Command::MoveCursor(Direction::FirstLine, 0));
 
         // editing
-        keymap.bind_keys(&[Key::Char('d'), Key::Char('W')], Command::Delete(Direction::RightWord(WordEdgeMatch::Whitespace), 1));
-        keymap.bind_keys(&[Key::Char('d'), Key::Char('B')], Command::Delete(Direction::LeftWord(WordEdgeMatch::Whitespace), 1));
-        keymap.bind_keys(&[Key::Char('d'), Key::Char('w')], Command::Delete(Direction::RightWord(WordEdgeMatch::Alphabet), 1));
-        keymap.bind_keys(&[Key::Char('d'), Key::Char('b')], Command::Delete(Direction::LeftWord(WordEdgeMatch::Alphabet), 1));
-        keymap.bind_key(Key::Char('x'), Command::Delete(Direction::Right, 1));
-        keymap.bind_key(Key::Char('X'), Command::Delete(Direction::Left, 1));
+        // keymap.bind_keys(&[Key::Char('d'), Key::Char('W')], Command::Delete(Direction::RightWord(WordEdgeMatch::Whitespace), 1));
+        // keymap.bind_keys(&[Key::Char('d'), Key::Char('B')], Command::Delete(Direction::LeftWord(WordEdgeMatch::Whitespace), 1));
+        // keymap.bind_keys(&[Key::Char('d'), Key::Char('w')], Command::Delete(Direction::RightWord(WordEdgeMatch::Alphabet), 1));
+        // keymap.bind_keys(&[Key::Char('d'), Key::Char('b')], Command::Delete(Direction::LeftWord(WordEdgeMatch::Alphabet), 1));
+        // keymap.bind_key(Key::Char('x'), Command::Delete(Direction::Right, 1));
+        // keymap.bind_key(Key::Char('X'), Command::Delete(Direction::Left, 1));
 
-        keymap.bind_key(Key::Char('u'), Command {
-            number: 1,
-            action: Action::Operation(Operation::Undo),
-            object: None
-        });
-        keymap.bind_key(Key::Ctrl('r'), Command {
-            number: 1,
-            action: Action::Operation(Operation::Redo),
-            object: None
-        });
+        keymap.bind_key(Key::Char('u'), command::Command::undo());
+        keymap.bind_key(Key::Ctrl('r'), command::Command::redo());
 
         keymap
     }
@@ -65,6 +57,16 @@ impl NormalMode {
 impl Mode for NormalMode {
     /// Given a key, pass it through the NormalMode KeyMap and return the associated Command, if any.
     fn handle_key_event(&mut self, key: Key) -> command::BuilderEvent {
-        self.builder.check_key(key)
+        match self.builder.check_key(key) {
+            command::BuilderEvent::Complete(cmd) => command::BuilderEvent::Complete(cmd),
+            command::BuilderEvent::Incomplete => {
+                if let KeyMapState::Match(c) = self.keymap.check_key(key) {
+                    command::BuilderEvent::Complete(c)
+                } else {
+                    command::BuilderEvent::Incomplete
+                }
+            }
+            command::BuilderEvent::Invalid => { command::BuilderEvent::Invalid }
+        }
     }
 }

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -3,10 +3,23 @@ use super::KeyMap;
 use super::Key;
 use super::KeyMapState;
 use super::Direction;
+use buffer::Mark;
+use command::{BuilderEvent, Operation, Instruction, Command, Action};
+use textobject::{Anchor, Kind, TextObject, Offset};
 
-use command::{BuilderEvent, Operation, Command, Action};
-use textobject::{Kind, TextObject, Offset};
 
+// TODO: move this somewhere else - probably command module
+fn movement(offset: Offset, kind: Kind) -> Command {
+    Command {
+        number: 0,
+        action: Action::Instruction(Instruction::SetMark(Mark::Cursor(0))),
+        object: TextObject {
+            kind: kind,
+            offset: offset
+        }
+    }
+
+}
 
 /// Standard mode is Iota's default mode.
 ///
@@ -39,16 +52,16 @@ impl StandardMode {
         keymap.bind_keys(vec![Key::Ctrl('x'), Key::Ctrl('c')].as_slice(), Command::exit_editor());
         keymap.bind_keys(vec![Key::Ctrl('x'), Key::Ctrl('s')].as_slice(), Command::save_buffer());
 
-        // // Navigation
-        // keymap.bind_key(Key::Up, Command::MoveCursor(Direction::Up, 1));
-        // keymap.bind_key(Key::Down, Command::MoveCursor(Direction::Down, 1));
-        // keymap.bind_key(Key::Left, Command::MoveCursor(Direction::Left, 1));
-        // keymap.bind_key(Key::Right, Command::MoveCursor(Direction::Right, 1));
+        keymap.bind_key(Key::Up, movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
+        keymap.bind_key(Key::Down, movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
+        keymap.bind_key(Key::Left, movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
+        keymap.bind_key(Key::Right, movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
 
-        // keymap.bind_key(Key::Ctrl('p'), Command::MoveCursor(Direction::Up, 1));
-        // keymap.bind_key(Key::Ctrl('n'), Command::MoveCursor(Direction::Down, 1));
-        // keymap.bind_key(Key::Ctrl('b'), Command::MoveCursor(Direction::Left, 1));
-        // keymap.bind_key(Key::Ctrl('f'), Command::MoveCursor(Direction::Right, 1));
+        keymap.bind_key(Key::Ctrl('p'), movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
+        keymap.bind_key(Key::Ctrl('n'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
+        keymap.bind_key(Key::Ctrl('b'), movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
+        keymap.bind_key(Key::Ctrl('f'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
+
         // keymap.bind_key(Key::Ctrl('e'), Command::LineEnd);
         // keymap.bind_key(Key::Ctrl('a'), Command::LineStart);
 

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -1,24 +1,12 @@
-use super::Mode;
-use super::KeyMap;
-use super::Key;
-use super::KeyMapState;
+use keyboard::Key;
+use keymap::{KeyMap, KeyMapState};
 use buffer::Mark;
 use command::{BuilderEvent, Operation, Instruction, Command, Action};
 use textobject::{Anchor, Kind, TextObject, Offset};
 
+use super::Mode;
 
-// TODO: move this somewhere else - probably command module
-fn movement(offset: Offset, kind: Kind) -> Command {
-    Command {
-        number: 1,
-        action: Action::Instruction(Instruction::SetMark(Mark::Cursor(0))),
-        object: Some(TextObject {
-            kind: kind,
-            offset: offset
-        })
-    }
 
-}
 
 /// Standard mode is Iota's default mode.
 ///
@@ -52,16 +40,16 @@ impl StandardMode {
         keymap.bind_keys(vec![Key::Ctrl('x'), Key::Ctrl('s')].as_slice(), Command::save_buffer());
 
         // Cursor movement
-        keymap.bind_key(Key::Up, movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
-        keymap.bind_key(Key::Down, movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
-        keymap.bind_key(Key::Left, movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
-        keymap.bind_key(Key::Right, movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
-        keymap.bind_key(Key::Ctrl('p'), movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Line(Anchor::End)));
-        keymap.bind_key(Key::Ctrl('n'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::End)));
-        keymap.bind_key(Key::Ctrl('b'), movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
-        keymap.bind_key(Key::Ctrl('f'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
-        keymap.bind_key(Key::Ctrl('e'), movement(Offset::Forward(0, Mark::Cursor(0)), Kind::Line(Anchor::End)));
-        keymap.bind_key(Key::Ctrl('a'), movement(Offset::Backward(0, Mark::Cursor(0)), Kind::Line(Anchor::Start)));
+        keymap.bind_key(Key::Up, Command::movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
+        keymap.bind_key(Key::Down, Command::movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
+        keymap.bind_key(Key::Left, Command::movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
+        keymap.bind_key(Key::Right, Command::movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
+        keymap.bind_key(Key::Ctrl('p'), Command::movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Line(Anchor::End)));
+        keymap.bind_key(Key::Ctrl('n'), Command::movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::End)));
+        keymap.bind_key(Key::Ctrl('b'), Command::movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
+        keymap.bind_key(Key::Ctrl('f'), Command::movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
+        keymap.bind_key(Key::Ctrl('e'), Command::movement(Offset::Forward(0, Mark::Cursor(0)), Kind::Line(Anchor::End)));
+        keymap.bind_key(Key::Ctrl('a'), Command::movement(Offset::Backward(0, Mark::Cursor(0)), Kind::Line(Anchor::Start)));
 
         // Editing
         keymap.bind_key(Key::Tab, Command::insert_tab());

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -11,7 +11,7 @@ use textobject::{Anchor, Kind, TextObject, Offset};
 // TODO: move this somewhere else - probably command module
 fn movement(offset: Offset, kind: Kind) -> Command {
     Command {
-        number: 0,
+        number: 1,
         action: Action::Instruction(Instruction::SetMark(Mark::Cursor(0))),
         object: Some(TextObject {
             kind: kind,

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -62,8 +62,8 @@ impl StandardMode {
         keymap.bind_key(Key::Ctrl('b'), movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
         keymap.bind_key(Key::Ctrl('f'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
 
-        // keymap.bind_key(Key::Ctrl('e'), Command::LineEnd);
-        // keymap.bind_key(Key::Ctrl('a'), Command::LineStart);
+        keymap.bind_key(Key::Ctrl('e'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::End)));
+        keymap.bind_key(Key::Ctrl('a'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::Start)));
 
         // // Editing
         // keymap.bind_key(Key::Tab, Command::InsertTab);

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -67,7 +67,7 @@ impl StandardMode {
 
         // // Editing
         // keymap.bind_key(Key::Tab, Command::InsertTab);
-        // keymap.bind_key(Key::Enter, Command::InsertChar('\n'));
+        keymap.bind_key(Key::Enter, Command::insert_char('\n'));
         // keymap.bind_key(Key::Backspace, Command::Delete(Direction::Left, 1));
         // keymap.bind_key(Key::Ctrl('h'), Command::Delete(Direction::Left, 1));
         // keymap.bind_key(Key::Delete, Command::Delete(Direction::Right, 1));
@@ -88,14 +88,7 @@ impl Mode for StandardMode {
     fn handle_key_event(&mut self, key: Key) -> BuilderEvent {
 
         if let Key::Char(c) = key {
-            BuilderEvent::Complete(Command {
-                number: 1,
-                action: Action::Operation(Operation::Insert(c)),
-                object: TextObject {
-                    kind: Kind::Char,
-                    offset: Offset::Absolute(0)
-                }
-            })
+            BuilderEvent::Complete(Command::insert_char(c))
         } else {
             if let KeyMapState::Match(c) = self.keymap.check_key(key) {
                 BuilderEvent::Complete(c)

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -1,7 +1,7 @@
 use keyboard::Key;
 use keymap::{KeyMap, KeyMapState};
 use buffer::Mark;
-use command::{BuilderEvent, Operation, Instruction, Command, Action};
+use command::{BuilderEvent, Operation, Command, Action};
 use textobject::{Anchor, Kind, TextObject, Offset};
 
 use super::Mode;

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -101,16 +101,8 @@ impl StandardMode {
         });
 
         // History
-        keymap.bind_key(Key::Ctrl('z'), Command {
-            number: 1,
-            action: Action::Operation(Operation::Undo),
-            object: None
-        });
-        keymap.bind_key(Key::Ctrl('y'), Command {
-            number: 1,
-            action: Action::Operation(Operation::Redo),
-            object: None
-        });
+        keymap.bind_key(Key::Ctrl('z'), Command::undo());
+        keymap.bind_key(Key::Ctrl('y'), Command::redo());
 
         keymap
     }

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -52,21 +52,20 @@ impl StandardMode {
         keymap.bind_keys(vec![Key::Ctrl('x'), Key::Ctrl('c')].as_slice(), Command::exit_editor());
         keymap.bind_keys(vec![Key::Ctrl('x'), Key::Ctrl('s')].as_slice(), Command::save_buffer());
 
+        // Cursor movement
         keymap.bind_key(Key::Up, movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
         keymap.bind_key(Key::Down, movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
         keymap.bind_key(Key::Left, movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
         keymap.bind_key(Key::Right, movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
-
         keymap.bind_key(Key::Ctrl('p'), movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
         keymap.bind_key(Key::Ctrl('n'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
         keymap.bind_key(Key::Ctrl('b'), movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
         keymap.bind_key(Key::Ctrl('f'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
-
         keymap.bind_key(Key::Ctrl('e'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::End)));
         keymap.bind_key(Key::Ctrl('a'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::Start)));
 
         // // Editing
-        // keymap.bind_key(Key::Tab, Command::InsertTab);
+        keymap.bind_key(Key::Tab, Command::insert_tab());
         keymap.bind_key(Key::Enter, Command::insert_char('\n'));
         // keymap.bind_key(Key::Backspace, Command::Delete(Direction::Left, 1));
         // keymap.bind_key(Key::Ctrl('h'), Command::Delete(Direction::Left, 1));

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -6,6 +6,9 @@ use super::KeyMapState;
 use super::Direction;
 
 use command;
+use command::Action;
+use textobject::{Kind, TextObject, Offset};
+
 
 /// Standard mode is Iota's default mode.
 ///
@@ -72,16 +75,18 @@ impl Mode for StandardMode {
     /// Given a key, pass it through the StandardMode KeyMap and return the associated Command, if any.
     /// If no match is found, treat it as an InsertChar command.
     fn handle_key_event(&mut self, key: Key) -> command::BuilderEvent {
-        // FIXME
-        command::BuilderEvent::Incomplete
-        // if let KeyMapState::Match(command) = self.keymap.check_key(key) {
-        //     return command
-        // }
 
-        // if let Key::Char(c) = key {
-        //     Command::InsertChar(c)
-        // } else {
-        //     Command::None
-        // }
+        if let Key::Char(c) = key {
+            command::BuilderEvent::Complete(command::Command {
+                number: 1,
+                action: command::Action::Operation(command::Operation::Insert(c)),
+                object: TextObject {
+                    kind: Kind::Char,
+                    offset: Offset::Absolute(0)
+                }
+            })
+        } else {
+            command::BuilderEvent::Incomplete
+        }
     }
 }

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -72,9 +72,23 @@ impl StandardMode {
         // keymap.bind_key(Key::Delete, Command::Delete(Direction::Right, 1));
         // keymap.bind_key(Key::Ctrl('d'), Command::Delete(Direction::Right, 1));
 
-        // // History
-        // keymap.bind_key(Key::Ctrl('y'), Command::Redo);
-        // keymap.bind_key(Key::Ctrl('z'), Command::Undo);
+        // History
+        keymap.bind_key(Key::Ctrl('z'), Command {
+            number: 1,
+            action: Action::Operation(Operation::Undo),
+            object: TextObject {
+                kind: Kind::Char,
+                offset: Offset::Absolute(0)
+            }
+        });
+        keymap.bind_key(Key::Ctrl('y'), Command {
+            number: 1,
+            action: Action::Operation(Operation::Redo),
+            object: TextObject {
+                kind: Kind::Char,
+                offset: Offset::Absolute(0)
+            }
+        });
 
         keymap
     }

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -64,13 +64,41 @@ impl StandardMode {
         keymap.bind_key(Key::Ctrl('e'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::End)));
         keymap.bind_key(Key::Ctrl('a'), movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::Start)));
 
-        // // Editing
+        // Editing
         keymap.bind_key(Key::Tab, Command::insert_tab());
         keymap.bind_key(Key::Enter, Command::insert_char('\n'));
-        // keymap.bind_key(Key::Backspace, Command::Delete(Direction::Left, 1));
-        // keymap.bind_key(Key::Ctrl('h'), Command::Delete(Direction::Left, 1));
-        // keymap.bind_key(Key::Delete, Command::Delete(Direction::Right, 1));
-        // keymap.bind_key(Key::Ctrl('d'), Command::Delete(Direction::Right, 1));
+        keymap.bind_key(Key::Backspace, Command {
+            number: 1,
+            action: Action::Operation(Operation::Delete),
+            object: TextObject {
+                kind: Kind::Char,
+                offset: Offset::Backward(1, Mark::Cursor(0))
+            }
+        });
+        keymap.bind_key(Key::Delete, Command {
+            number: 1,
+            action: Action::Operation(Operation::Delete),
+            object: TextObject {
+                kind: Kind::Char,
+                offset: Offset::Forward(1, Mark::Cursor(0))
+            }
+        });
+        keymap.bind_key(Key::Ctrl('h'), Command {
+            number: 1,
+            action: Action::Operation(Operation::Delete),
+            object: TextObject {
+                kind: Kind::Char,
+                offset: Offset::Backward(1, Mark::Cursor(0))
+            }
+        });
+        keymap.bind_key(Key::Ctrl('d'), Command {
+            number: 1,
+            action: Action::Operation(Operation::Delete),
+            object: TextObject {
+                kind: Kind::Char,
+                offset: Offset::Forward(1, Mark::Cursor(0))
+            }
+        });
 
         // History
         keymap.bind_key(Key::Ctrl('z'), Command {

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -2,7 +2,6 @@ use super::Mode;
 use super::KeyMap;
 use super::Key;
 use super::KeyMapState;
-use super::Direction;
 use buffer::Mark;
 use command::{BuilderEvent, Operation, Instruction, Command, Action};
 use textobject::{Anchor, Kind, TextObject, Offset};

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -13,10 +13,10 @@ fn movement(offset: Offset, kind: Kind) -> Command {
     Command {
         number: 0,
         action: Action::Instruction(Instruction::SetMark(Mark::Cursor(0))),
-        object: TextObject {
+        object: Some(TextObject {
             kind: kind,
             offset: offset
-        }
+        })
     }
 
 }
@@ -70,52 +70,46 @@ impl StandardMode {
         keymap.bind_key(Key::Backspace, Command {
             number: 1,
             action: Action::Operation(Operation::Delete),
-            object: TextObject {
+            object: Some(TextObject {
                 kind: Kind::Char,
                 offset: Offset::Backward(1, Mark::Cursor(0))
-            }
+            })
         });
         keymap.bind_key(Key::Delete, Command {
             number: 1,
             action: Action::Operation(Operation::Delete),
-            object: TextObject {
+            object: Some(TextObject {
                 kind: Kind::Char,
                 offset: Offset::Forward(1, Mark::Cursor(0))
-            }
+            })
         });
         keymap.bind_key(Key::Ctrl('h'), Command {
             number: 1,
             action: Action::Operation(Operation::Delete),
-            object: TextObject {
+            object: Some(TextObject {
                 kind: Kind::Char,
                 offset: Offset::Backward(1, Mark::Cursor(0))
-            }
+            })
         });
         keymap.bind_key(Key::Ctrl('d'), Command {
             number: 1,
             action: Action::Operation(Operation::Delete),
-            object: TextObject {
+            object: Some(TextObject {
                 kind: Kind::Char,
                 offset: Offset::Forward(1, Mark::Cursor(0))
-            }
+            })
         });
 
         // History
         keymap.bind_key(Key::Ctrl('z'), Command {
             number: 1,
             action: Action::Operation(Operation::Undo),
-            object: TextObject {
-                kind: Kind::Char,
-                offset: Offset::Absolute(0)
-            }
+            object: None
         });
         keymap.bind_key(Key::Ctrl('y'), Command {
             number: 1,
             action: Action::Operation(Operation::Redo),
-            object: TextObject {
-                kind: Kind::Char,
-                offset: Offset::Absolute(0)
-            }
+            object: None
         });
 
         keymap

--- a/src/iota/textobject.rs
+++ b/src/iota/textobject.rs
@@ -43,9 +43,9 @@ impl Default for Kind {
 #[allow(dead_code)]
 pub enum Anchor {
     Before,     // Index just prior to TextObject
-    // Start,   // First index within TextObject
+    Start,      // First index within TextObject
     // Middle,  // Middle index of TextObject
-    // End,     // Last index within TextObject
+    End,        // Last index within TextObject
     After,      // First index after TextObject
     Same,       // Same as index within current TextObject of the same Kind
 }

--- a/src/iota/textobject.rs
+++ b/src/iota/textobject.rs
@@ -1,6 +1,6 @@
 use std::default::Default;
 
-use buffer::{ Direction, Mark, WordEdgeMatch };
+use buffer::Mark;
 
 #[derive(Copy, Debug)]
 #[allow(dead_code)]

--- a/src/iota/textobject.rs
+++ b/src/iota/textobject.rs
@@ -2,7 +2,7 @@ use std::default::Default;
 
 use buffer::{ Direction, Mark, WordEdgeMatch };
 
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 #[allow(dead_code)]
 pub enum Kind {
     Char,
@@ -39,7 +39,7 @@ impl Default for Kind {
     }
 }
 
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 #[allow(dead_code)]
 pub enum Anchor {
     Before,     // Index just prior to TextObject
@@ -56,7 +56,7 @@ impl Default for Anchor {
     }
 }
 
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 #[allow(dead_code)]
 pub enum Offset {
     Absolute(usize),
@@ -80,7 +80,7 @@ impl Default for Offset {
     }
 }
 
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 pub struct TextObject {
     pub kind: Kind,
     pub offset: Offset

--- a/src/iota/uibuf.rs
+++ b/src/iota/uibuf.rs
@@ -178,8 +178,8 @@ mod tests {
     #[test]
     fn update_cell_updates_all_attrs_of_cell() {
         let mut uibuf = setup_uibuf();
-        let cell_num = 10us;
-        let row_num = 0us;
+        let cell_num = 10;
+        let row_num = 0;
         let ch = 'q';
         let fg = CharColor::Default;
         let bg = CharColor::Blue;

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -226,13 +226,6 @@ impl<'v> View<'v> {
         }
     }
 
-    pub fn insert_tab(&mut self) {
-        // A tab is just 4 spaces
-        for _ in range(0, 4) {
-            self.insert_char(' ');
-        }
-    }
-
     /// Insert a chacter into the buffer & update cursor position accordingly.
     pub fn insert_char(&mut self, ch: char) {
         self.buffer.insert_char(self.cursor, ch as u8);

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -368,7 +368,7 @@ mod tests {
     use view::View;
     use input::Input;
 
-    fn setup_view<'v>(testcase: &'static str) -> View<'v> {
+    fn setup_view(testcase: &'static str) -> View {
         let mut view = View::new(Input::Filename(None), 50, 50);
         for ch in testcase.chars() {
             view.insert_char(ch);

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -100,6 +100,7 @@ impl View {
         self.uibuf.draw_everything(frontend);
     }
 
+    // FIXME: should probably use draw_line here...
     pub fn draw<T: Frontend>(&mut self, frontend: &mut T) {
         let height = self.get_height() - 2;
         let width = self.get_width();

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -10,8 +10,6 @@ use overlay::{Overlay, OverlayType};
 use utils;
 use textobject::{Anchor, TextObject, Kind, Offset};
 
-use buffer::WordEdgeMatch;
-
 /// A View is an abstract Window (into a Buffer).
 ///
 /// It draws a portion of a Buffer to a UIBuffer which in turn is drawn to the

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -165,7 +165,7 @@ impl<'v> View<'v> {
         }
     }
 
-    pub fn move_mark(&mut self, object: TextObject, num: usize) {
+    pub fn move_mark(&mut self, mark: Mark, object: TextObject, num: usize) {
         // TODO: move all this to buffer
         //       Buffer should take the entire command and do stuff with it.
         //       eg:
@@ -174,12 +174,6 @@ impl<'v> View<'v> {
         //           self.buffer.shift_mark(object)
         //       }
         //
-        let mark = match object.offset {
-            Offset::Forward(_, mark) => mark,
-            Offset::Backward(_, mark) => mark,
-            _ => { return } // no mark found
-        };
-
         let mut dir = match object.offset {
             Offset::Backward(_, _) => Direction::Left,
             Offset::Forward(_, _) => Direction::Right,

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -101,7 +101,7 @@ impl View {
     }
 
     pub fn draw<T: Frontend>(&mut self, frontend: &mut T) {
-        let height = self.get_height();
+        let height = self.get_height() - 2;
         let width = self.get_width();
         let mut line = 0;
         let mut col = 0;

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -250,7 +250,7 @@ impl<'v> View<'v> {
 
     pub fn delete_from_mark_to_object(&mut self, mark: Mark, object: TextObject) {
         use std::cmp;
-        if let Some(idx) = self.buffer.get_object_index(object) {
+        if let Some((idx, _)) = self.buffer.get_object_index(object) {
             if let Some(midx) = self.buffer.get_mark_idx(mark) {
                 self.buffer.remove_from_mark_to_object(mark, object);
                 self.buffer.set_mark(mark, cmp::min(idx, midx));


### PR DESCRIPTION
The command builder is a mechanism for composing commands which can be interpreted by Iota. These commands use structures called text objects which can refer to any object inside a buffer (char, line, word etc).

Thanks to @crespyl for most of the design and implementation on this.

Fixes #89 