### PR TITLE
fix some issues with drawing a view in standard mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CARGO=/usr/local/bin/cargo
+CARGO=$(or $(shell which cargo 2> /dev/null),/usr/local/bin/cargo)
 OPTS=
 
 all: release

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -131,8 +131,9 @@ impl View {
             // FIXME: don't use unwrap here
             //        This will fail if for some reason the buffer doesnt have
             //        the top_line mark
-            let lines = buffer.lines_from(self.top_line).unwrap().take(height);
-            for (y_position, line) in lines.enumerate() {
+            let mut lines = buffer.lines_from(self.top_line).unwrap().take(height);
+            for y_position in 0..height {
+                let line = lines.next().unwrap_or(vec![]);
                 draw_line(&mut self.uibuf, line.as_slice(), y_position, self.left_col);
             }
 

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -385,6 +385,9 @@ pub fn draw_line(buf: &mut UIBuffer, line: &[u8], idx: usize, left: usize) {
                 x += ch.width(false).unwrap_or(1);
             }
         }
+        if x >= width {
+            break;
+        }
     }
     
     // Replace any cells after end of line with ' '

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -123,35 +123,17 @@ impl View {
         self.uibuf.draw_everything(frontend);
     }
 
-    // FIXME: should probably use draw_line here...
     pub fn draw<T: Frontend>(&mut self, frontend: &mut T) {
         {
             let buffer = self.buffer.lock().unwrap();
-            let height = self.get_height() - 2;
-            let width = self.get_width();
-            let mut line = 0;
-            let mut col = 0;
+            let height = self.get_height() - 1;
 
             // FIXME: don't use unwrap here
             //        This will fail if for some reason the buffer doesnt have
             //        the top_line mark
-            for c in buffer.chars_from(self.top_line).unwrap() {
-                if c == '\n' {
-                    // clear everything after the end of the line content
-                    for i in col..width {
-                        self.uibuf.update_cell_content(i, line, ' ');
-                    }
-
-                    if line == height {
-                        break;
-                    }
-
-                    col = 0;
-                    line += 1;
-                } else {
-                    self.uibuf.update_cell_content(col, line, c);
-                    col += 1;
-                }
+            let lines = buffer.lines_from(self.top_line).unwrap().take(height);
+            for (y_position, line) in lines.enumerate() {
+                draw_line(&mut self.uibuf, line.as_slice(), y_position, self.left_col);
             }
 
         }

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -369,7 +369,7 @@ pub fn draw_line(buf: &mut UIBuffer, line: &[u8], idx: usize, left: usize) {
     let width = buf.get_width() - 1;
     let mut x = 0;
     
-    for ch in line.iter().skip(left).take(width) {
+    for ch in line.iter().skip(left) {
         let ch = *ch as char;
         match ch {
             '\t' => {


### PR DESCRIPTION
Hi,

This fixes some issues where a view is incorrectly drawn while editing in standard mode:

- Deleting characters on the last line of a buffer visually duplicated the last character in the line
- Deleting lines when the height of the buffer was shorter than the height of the UI visually duplicated the last line of the file
- There were several problems with editing lines longer than the width of the UI (for example, shortening a line would never get rid of the "→" indicator at the end).

There are still some problems which I notice when editing unicode characters. It looks like the `GapBuffer<u8>` is being treated as an array of codepoints rather than an array of bytes. Of course, this doesn't work for codepoints greater than 255. Is the gap buffer meant to store codepoints? If so, would it be a good idea to change it to a `GapBuffer<char>`?

I've also edited the Makefile to work when `cargo` isn't located in `/usr/local/bin`.