### PR TITLE
fix `arithmetic operation overflowed`

### DIFF
--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -302,6 +302,8 @@ impl Buffer {
                         new_mark_pos.absolute = cmp::min(mark_pos.absolute - mark_pos.absolute_line_start, nlines[0]);
                     } else if offset > nlines.len() {
                         return Some(new_mark_pos)
+                    } else if offset > mark_pos.line_number {
+                        return Some(new_mark_pos)
                     } else if offset == 0 {
                         return Some(new_mark_pos)
                     } else {


### PR DESCRIPTION
steps to reproduce:

1. `iota --vi README.md`
2. `jjjbk`

"move one word backward" behavior seems wrong.

```
     Running `target/debug/iota --vi README.md`
thread '<main>' panicked at 'arithmetic operation overflowed', src/iota/buffer.rs:310
stack backtrace:
   1:     0x56052a9ab210 - sys::backtrace::tracing::imp::write::h1c67167e36198df5Qwu
   2:     0x56052a9ae5ab - panicking::default_handler::_$u7b$$u7b$closure$u7d$$u7d$::closure.43471
   3:     0x56052a9ae218 - panicking::default_handler::h9023da11475bdb1dA3y
   4:     0x56052a99fbac - sys_common::unwind::begin_unwind_inner::hf5ab264a07c201cdFlt
   5:     0x56052a99fff8 - sys_common::unwind::begin_unwind_fmt::hd9d6d1b19c7960d2Lkt
   6:     0x56052a9aa701 - rust_begin_unwind
   7:     0x56052a9d710f - panicking::panic_fmt::h62352977d16cc5446YL
   8:     0x56052a9d73e8 - panicking::panic::he36bffa3158bb900DXL
   9:     0x56052a85939c - buffer::Buffer::get_line_index_backward::hccf2332e51aa6c06Qwa
                        at src/iota/buffer.rs:310
  10:     0x56052a857955 - buffer::Buffer::get_line_index::h9dd919bd9b814105Nta
                        at src/iota/buffer.rs:225
  11:     0x56052a85722e - buffer::Buffer::get_object_index::h7ad693721815990eXqa
                        at src/iota/buffer.rs:141
  12:     0x56052a85dcce - buffer::Buffer::set_mark_to_object::h13040953f40f6bc71Na
                        at src/iota/buffer.rs:508
  13:     0x56052a86ccd4 - view::View::move_mark::h2283659049b22eccWJb
                        at src/iota/view.rs:208
  14:     0x56052a84d80a - editor::Editor<'e, T>::handle_instruction::h16327850811678013980
                        at src/iota/editor.rs:174
  15:     0x56052a84d245 - editor::Editor<'e, T>::handle_command::h15209287566117992244
                        at src/iota/editor.rs:161
  16:     0x56052a84c566 - editor::Editor<'e, T>::handle_key_event::h1659430630403727501
                        at src/iota/editor.rs:86
  17:     0x56052a848ef6 - editor::Editor<'e, T>::start::h5983973856314194529
                        at src/iota/editor.rs:225
  18:     0x56052a838fc0 - main::h664c38f33474903aeda
                        at src/main.rs:77
  19:     0x56052a9ade74 - sys_common::unwind::try::try_fn::h14839783617401448156
  20:     0x56052a9aa68b - __rust_try
  21:     0x56052a9ad8fe - rt::lang_start::h5fa2ad55c2a21093GVy
  22:     0x56052a84e079 - main
  23:     0x7f9529ce260f - __libc_start_main
  24:     0x56052a8384b8 - _start
  25:                0x0 - <unknown>
Process didn't exit successfully: `target/debug/iota --vi README.md` (exit code: 101)
```