### PR TITLE
fixed some clippy warnings

### DIFF
--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -495,7 +495,7 @@ impl Buffer {
     pub fn status_text(&self) -> String {
         match self.file_path {
             Some(ref path)  =>  format!("[{}] ", path.display()),
-            None            =>  format!("untitled "),
+            None            =>  "untitled ".into(),
         }
     }
 
@@ -676,14 +676,14 @@ fn get_line_info(mark: usize, text: &GapBuffer<u8>) -> Option<MarkPosition> {
     let line_starts: Vec<usize> = (0..val + 1).rev().filter(|idx| *idx == 0 || text[*idx - 1] == b'\n').collect();
 
 
-    if !line_starts.is_empty() {
+    if line_starts.is_empty() {
+        None
+    } else {
         let mut mark_pos = MarkPosition::start();
         mark_pos.absolute_line_start = line_starts[0];
         mark_pos.line_number = line_starts.len() - 1;
         mark_pos.absolute = mark;
         Some(mark_pos)
-    } else {
-        None
     }
 
 }

--- a/src/iota/command.rs
+++ b/src/iota/command.rs
@@ -22,7 +22,7 @@ pub enum Instruction {
 
 /// Operations on the Buffer.
 /// These DO alter the text, but otherwise may NOT change editor/view state
-/// Note that these differ from log::Change in that they are higher-level
+/// Note that these differ from `log::Change` in that they are higher-level
 /// operations dependent on state (cursor/mark locations, etc.), as opposed
 /// to concrete operations on absolute indexes (insert 'a' at index 158, etc.)
 #[derive(Copy, Clone, Debug)]

--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -114,12 +114,12 @@ impl<'e, T: Frontend> Editor<'e, T> {
                     }
 
                     Overlay::SavePrompt { .. } => {
-                        if !data.is_empty() {
+                        if data.is_empty() {
+                            BuilderEvent::Invalid
+                        } else {
                             let path = PathBuf::from(&*data);
                             self.view.buffer.lock().unwrap().file_path = Some(path);
                             BuilderEvent::Complete(Command::save_buffer())
-                        } else {
-                            BuilderEvent::Invalid
                         }
                     }
 

--- a/src/iota/frontends/mod.rs
+++ b/src/iota/frontends/mod.rs
@@ -5,7 +5,7 @@ pub use self::rb::RustboxFrontend;
 
 /// A general means of representing events from different frontends.
 ///
-/// A frontend should translate its own events into an EditorEvent to be used
+/// A frontend should translate its own events into an `EditorEvent` to be used
 /// elsewhere in the program.
 pub enum EditorEvent {
     KeyEvent(Option<Key>),

--- a/src/iota/frontends/rb.rs
+++ b/src/iota/frontends/rb.rs
@@ -71,7 +71,7 @@ impl<'f> Frontend for RustboxFrontend<'f> {
     }
 }
 
-/// Translate a CharColor to rustbox::Color
+/// Translate a `CharColor` to `rustbox::Color`
 fn get_color(c: CharColor) -> Color {
     match c {
         CharColor::Default => Color::Default,
@@ -80,7 +80,7 @@ fn get_color(c: CharColor) -> Color {
     }
 }
 
-/// Translate a CharStyle to rustbox::Style
+/// Translate a `CharStyle` to `rustbox::Style`
 fn get_style(s: CharStyle) -> Style {
     match s {
         CharStyle::Normal => Style::empty(),

--- a/src/iota/iterators.rs
+++ b/src/iota/iterators.rs
@@ -10,17 +10,16 @@ impl<'a> Iterator for Lines<'a> {
     type Item = Vec<u8>;
 
     fn next(&mut self) -> Option<Vec<u8>> {
-        if self.tail != self.head {
-            let old_tail = self.tail;
-            //update tail to either the first char after the next \n or to self.head
-            self.tail = (old_tail..self.head).filter(|i| { *i + 1 == self.head
-                                                           || self.buffer[*i] == b'\n' })
-                                             .take(1)
-                                             .next()
-                                             .unwrap() + 1;
-            Some((old_tail..if self.tail == self.head { self.tail - 1 } else { self.tail })
-                .map( |i| self.buffer[i] ).collect())
-        } else { None }
+        if self.tail == self.head { return None; }
+        let old_tail = self.tail;
+        //update tail to either the first char after the next \n or to self.head
+        self.tail = (old_tail..self.head).filter(|i| { *i + 1 == self.head
+                                                       || self.buffer[*i] == b'\n' })
+                                         .take(1)
+                                         .next()
+                                         .unwrap() + 1;
+        Some((old_tail..if self.tail == self.head { self.tail - 1 } else { self.tail })
+            .map( |i| self.buffer[i] ).collect())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/iota/keymap.rs
+++ b/src/iota/keymap.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use keyboard::Key;
 
 pub enum Trie<T: Copy> {
@@ -55,13 +56,14 @@ impl<T: Copy> Trie<T> {
                 Trie::Node(ref mut map) => {
                     let key = keys[0];
                     let keys = &keys[1..];
-
-                    if map.contains_key(&key) {
-                        map.get_mut(&key).unwrap().bind_keys(keys, value);
-                    } else {
-                        let mut node = Box::new(Trie::new());
-                        node.bind_keys(keys, value);
-                        map.insert(key, node);
+                    match map.entry(key) {
+                        Entry::Vacant(v) => {
+                            let mut node = Box::new(Trie::new());
+                            node.bind_keys(keys, value);
+                            v.insert(node);
+                        },
+                        Entry::Occupied(mut o) =>
+                            o.get_mut().bind_keys(keys, value)
                     }
                 }
             }

--- a/src/iota/log.rs
+++ b/src/iota/log.rs
@@ -108,7 +108,7 @@ impl Log {
     ///
     /// This returns a RAII guard that can be used to record edits during the transaction.
     #[cfg_attr(feature="clippy", allow(needless_lifetimes))]
-    pub fn start<'a>(&'a mut self, idx: usize) -> Transaction<'a> {
+    pub fn start(&mut self, idx: usize) -> Transaction {
         Transaction {
             entries: self,
             entry: LogEntry {

--- a/src/iota/modes/insert.rs
+++ b/src/iota/modes/insert.rs
@@ -5,21 +5,21 @@ use command::{BuilderEvent, Command};
 use super::{Mode, ModeType};
 
 
-/// InsertMode mimics Vi's Insert mode.
+/// `InsertMode` mimics Vi's Insert mode.
 pub struct InsertMode {
     keymap: KeyMap<Command>,
 }
 
 impl InsertMode {
 
-    /// Create a new instance of InsertMode
+    /// Create a new instance of `InsertMode`
     pub fn new() -> InsertMode {
         InsertMode {
             keymap: InsertMode::key_defaults(),
         }
     }
 
-    /// Creates a KeyMap with default InsertMode key bindings
+    /// Creates a `KeyMap` with default `InsertMode` key bindings
     fn key_defaults() -> KeyMap<Command> {
         let mut keymap = KeyMap::new();
 

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -5,7 +5,7 @@ use command::{Builder, BuilderEvent, Command};
 use super::{Mode, ModeType};
 
 
-/// NormalMode mimics Vi's Normal mode.
+/// `NormalMode` mimics Vi's Normal mode.
 pub struct NormalMode {
     keymap: KeyMap<Command>,
     builder: Builder,
@@ -13,7 +13,7 @@ pub struct NormalMode {
 
 impl NormalMode {
 
-    /// Create a new instance of NormalMode
+    /// Create a new instance of `NormalMode`
     pub fn new() -> NormalMode {
         NormalMode {
             keymap: NormalMode::key_defaults(),
@@ -21,7 +21,7 @@ impl NormalMode {
         }
     }
 
-    /// Creates a KeyMap with default NormalMode key bindings
+    /// Creates a `KeyMap` with default `NormalMode` key bindings
     fn key_defaults() -> KeyMap<Command> {
         let mut keymap = KeyMap::new();
 

--- a/src/iota/view.rs
+++ b/src/iota/view.rs
@@ -18,7 +18,7 @@ use textobject::{Anchor, TextObject, Kind, Offset};
 
 /// A View is an abstract Window (into a Buffer).
 ///
-/// It draws a portion of a Buffer to a UIBuffer which in turn is drawn to the
+/// It draws a portion of a Buffer to a `UIBuffer` which in turn is drawn to the
 /// screen. It maintains the status bar for the current view, the "dirty status"
 /// which is whether the buffer has been modified or not and a number of other
 /// pieces of information.
@@ -163,10 +163,9 @@ impl View {
 
 
         for index in 0..width {
-            let mut ch: char = ' ';
-            if index < status_text_len {
-                ch = status_text[index] as char;
-            }
+            let ch: char = if index < status_text_len {
+                status_text[index] as char
+            } else { ' ' };
             self.uibuf.update_cell(index, height, ch, CharColor::Black, CharColor::Blue);
         }
 
@@ -408,11 +407,10 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use view::View;
-    use input::Input;
     use buffer::Buffer;
 
     fn setup_view(testcase: &'static str) -> View {
-        let mut buffer = Arc::new(Mutex::new(Buffer::new()));
+        let buffer = Arc::new(Mutex::new(Buffer::new()));
         let mut view = View::new(buffer.clone(), 50, 50);
         for ch in testcase.chars() {
             view.insert_char(ch);


### PR DESCRIPTION
Mostly this is to make the code more readable, but you may like the usage of the Entry API in `src/iota/keymap.rs` and the use of an iterator instead of indexing  in `src/iota/view.rs`.

Cheers!