### PR TITLE
Replace Multirust with Rustup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ integration with Rust tooling. This could also be applied to other languages too
 
 Clone the project and run `make` or `cargo build --release`.
 
-**NOTE:** Iota needs to be built using the nightly toolchain for now, not 1.0.0. [Multirust](https://github.com/brson/multirust) is very useful for managing multiple rust versions.
+**NOTE:** Iota needs to be built using the nightly toolchain for now, not 1.0.0. [Rustup](https://github.com/rust-lang-nursery/rustup.rs) is very useful for managing multiple rust versions.
 
 Then to start the editor run `./target/release/iota /path/to/file.txt`. Or
 simply `./target/release/iota` to open an empty buffer.


### PR DESCRIPTION
Rustup is the successor of Multirust, the latter is now deprecated.