### PR TITLE
Added documentation for undocumented struct and public field

### DIFF
--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -20,7 +20,9 @@ use command::Command;
 use command::{Action, BuilderEvent, Operation, Instruction};
 
 
+/// Structure to handle flags and options passed to Iota
 pub struct Options {
+    /// True if syntax highlighting has been enabled
     pub syntax_enabled: bool,
 }
 


### PR DESCRIPTION
This fixes a couple of warnings.