### PR TITLE
Created new emacs mode and removed Emacs bindings from standard mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,12 @@ ifconfig | ./target/release/iota
 
 You can move the cursor around with the arrow keys.
 
-To save, press `Ctrl-s`.
-To exit, press `Ctrl-q`.
+The following keyboard bindings are also available:
+
+- `Ctrl-s` save
+- `Ctrl-q` quit
+- `Ctrl-z` undo
+- `Ctrl-y` redo
 
 Iota currently supports both Vi and Emacs style keybindings for simple movement.
 
@@ -94,7 +98,7 @@ just yet. The following works:
 - while in insert mode:
     - `ESC` normal mode
 
-Alternatively, you can use the following emacs-style keys:
+Alternatively, you can use the following emacs-style keys by using the `--emacs` flag:
 
 - `Ctrl-p` move up
 - `Ctrl-n` move down

--- a/src/iota/lib.rs
+++ b/src/iota/lib.rs
@@ -17,7 +17,7 @@ extern crate unicode_width;
 
 pub use editor::Editor;
 pub use input::Input;
-pub use modes::{StandardMode, NormalMode, Mode};
+pub use modes::{StandardMode, NormalMode, EmacsMode, Mode};
 
 mod input;
 mod utils;

--- a/src/iota/modes/emacs.rs
+++ b/src/iota/modes/emacs.rs
@@ -29,8 +29,6 @@ impl EmacsMode {
         let mut keymap = KeyMap::new();
 
         // Editor Commands
-        keymap.bind_key(Key::Ctrl('q'), Command::exit_editor());
-        keymap.bind_key(Key::Ctrl('s'), Command::save_buffer());
         keymap.bind_keys(&[Key::Ctrl('x'), Key::Ctrl('c')], Command::exit_editor());
         keymap.bind_keys(&[Key::Ctrl('x'), Key::Ctrl('s')], Command::save_buffer());
 
@@ -91,10 +89,6 @@ impl EmacsMode {
             action: Action::Instruction(Instruction::SwitchToLastBuffer),
             object: None
         });
-
-        // History
-        keymap.bind_key(Key::Ctrl('z'), Command::undo());
-        keymap.bind_key(Key::Ctrl('y'), Command::redo());
 
         keymap
     }

--- a/src/iota/modes/emacs.rs
+++ b/src/iota/modes/emacs.rs
@@ -1,49 +1,50 @@
 use keyboard::Key;
 use keymap::{KeyMap, KeyMapState};
 use buffer::Mark;
-use command::{BuilderEvent, Operation, Command, Action};
+use command::{BuilderEvent, Operation, Instruction, Command, Action};
 use textobject::{Anchor, Kind, TextObject, Offset};
 
 use super::Mode;
 
 
-
-/// Standard mode is Iota's default mode.
+/// Emacs mode uses Emacs-like keybindings.
 ///
-/// Standard mode uses non-vi-like keybindings.
-/// Unlike Normal, Command and Visual modes which are all used together, Standard
-/// mode is used on its own.
-///
-/// Standard mode allows Iota to be used in a non-modal way, similar to mainstream
-/// editors like Atom or Sublime.
-pub struct StandardMode {
+pub struct EmacsMode {
     keymap: KeyMap<Command>,
     match_in_progress: bool,
 }
 
-impl StandardMode {
+impl EmacsMode {
 
-    /// Create a new instance of StandardMode
-    pub fn new() -> StandardMode {
-        StandardMode {
-            keymap: StandardMode::key_defaults(),
+    /// Create a new instance of EmacsMode
+    pub fn new() -> EmacsMode {
+        EmacsMode {
+            keymap: EmacsMode::key_defaults(),
             match_in_progress: false,
         }
     }
 
-    /// Creates a KeyMap with default StandardMode key bindings
+    /// Creates a KeyMap with default EmacsMode key bindings
     fn key_defaults() -> KeyMap<Command> {
         let mut keymap = KeyMap::new();
 
         // Editor Commands
         keymap.bind_key(Key::Ctrl('q'), Command::exit_editor());
         keymap.bind_key(Key::Ctrl('s'), Command::save_buffer());
+        keymap.bind_keys(&[Key::Ctrl('x'), Key::Ctrl('c')], Command::exit_editor());
+        keymap.bind_keys(&[Key::Ctrl('x'), Key::Ctrl('s')], Command::save_buffer());
 
         // Cursor movement
         keymap.bind_key(Key::Up, Command::movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
         keymap.bind_key(Key::Down, Command::movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
         keymap.bind_key(Key::Left, Command::movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
         keymap.bind_key(Key::Right, Command::movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
+        keymap.bind_key(Key::Ctrl('p'), Command::movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
+        keymap.bind_key(Key::Ctrl('n'), Command::movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Line(Anchor::Same)));
+        keymap.bind_key(Key::Ctrl('b'), Command::movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
+        keymap.bind_key(Key::Ctrl('f'), Command::movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
+        keymap.bind_key(Key::Ctrl('e'), Command::movement(Offset::Forward(0, Mark::Cursor(0)), Kind::Line(Anchor::End)));
+        keymap.bind_key(Key::Ctrl('a'), Command::movement(Offset::Backward(0, Mark::Cursor(0)), Kind::Line(Anchor::Start)));
 
         // Editing
         keymap.bind_key(Key::Tab, Command::insert_tab());
@@ -71,6 +72,24 @@ impl StandardMode {
                 kind: Kind::Char,
                 offset: Offset::Backward(1, Mark::Cursor(0))
             })
+        });
+        keymap.bind_key(Key::Ctrl('d'), Command {
+            number: 1,
+            action: Action::Operation(Operation::DeleteFromMark(Mark::Cursor(0))),
+            object: Some(TextObject {
+                kind: Kind::Char,
+                offset: Offset::Forward(1, Mark::Cursor(0))
+            })
+        });
+        // keymap.bind_keys(&[Key::Ctrl('x'), Key::Ctrl('f')], Command {
+        //     number: 1,
+        //     action: Action::Instruction(Instruction::SetOverlay(OverlayType::SelectFile)),
+        //     object: None
+        // });
+        keymap.bind_keys(&[Key::Ctrl('x'), Key::Ctrl('b')], Command {
+            number: 1,
+            action: Action::Instruction(Instruction::SwitchToLastBuffer),
+            object: None
         });
 
         // History
@@ -108,8 +127,8 @@ impl StandardMode {
 
 }
 
-impl Mode for StandardMode {
-    /// Given a key, pass it through the StandardMode KeyMap and return the associated Command, if any.
+impl Mode for EmacsMode {
+    /// Given a key, pass it through the EmacsMode KeyMap and return the associated Command, if any.
     /// If no match is found, treat it as an InsertChar command.
     fn handle_key_event(&mut self, key: Key) -> BuilderEvent {
         if self.match_in_progress {
@@ -125,7 +144,7 @@ impl Mode for StandardMode {
     }
 }
 
-impl Default for StandardMode {
+impl Default for EmacsMode {
     fn default() -> Self {
         Self::new()
     }

--- a/src/iota/modes/mod.rs
+++ b/src/iota/modes/mod.rs
@@ -4,10 +4,12 @@ use command::BuilderEvent;
 pub use self::standard::StandardMode;
 pub use self::normal::NormalMode;
 pub use self::insert::InsertMode;
+pub use self::emacs::EmacsMode;
 
 mod standard;
 mod normal;
 mod insert;
+mod emacs;
 
 #[derive(Copy, Clone, Debug)]
 pub enum ModeType {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use std::io::stdin;
 use docopt::Docopt;
 use iota::{
     Editor, Input,
-    StandardMode, NormalMode,
+    StandardMode, NormalMode, EmacsMode,
     Mode,
 };
 use rustbox::{InitOptions, RustBox, InputMode, OutputMode};
@@ -19,6 +19,7 @@ Usage: iota [<filename>] [options]
        iota --help
 
 Options:
+    --emacs                        Start Iota with emacs-like mode
     --vi                           Start Iota with vi-like modes
     -h, --help                     Show this message.
 ";
@@ -27,6 +28,7 @@ Options:
 #[derive(RustcDecodable, Debug)]
 struct Args {
     arg_filename: Option<String>,
+    flag_emacs: bool,
     flag_vi: bool,
     flag_help: bool,
 }
@@ -66,6 +68,8 @@ fn main() {
     // initialise the editor mode
     let mode: Box<Mode> = if args.flag_vi {
         Box::new(NormalMode::new())
+    } else if args.flag_emacs {
+        Box::new(EmacsMode::new())    
     } else {
          Box::new(StandardMode::new())
     };


### PR DESCRIPTION
This separates emacs and standard mode as discussed in #134. Standard mode is the default, and emacs mode is available now via the --emacs flag. Readme updates are included to reflect this change.