### PR TITLE
Replace existing mark when using set_mark_to_object

### DIFF
--- a/src/iota/buffer.rs
+++ b/src/iota/buffer.rs
@@ -511,7 +511,7 @@ impl Buffer {
     /// Adds a new mark or overwrites an existing mark.
     pub fn set_mark_to_object(&mut self, mark: Mark, obj: TextObject) {
         if let Some(mark_pos) = self.get_object_index(obj) {
-            self.marks.insert(mark, mark_pos);
+            self.set_mark(mark, mark_pos.absolute);
         }
     }
 


### PR DESCRIPTION
This fixes the problem for me and doesn't seem to cause any issues. It looks like the check for an existing object wasn't included and was causing issues in this case for some reason.