### PR TITLE
Added Home/End and Ctrl-Arrow bindings

### DIFF
--- a/src/iota/editor.rs
+++ b/src/iota/editor.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 use std::sync::{Mutex, Arc};
 use std::sync::mpsc::{Sender, Receiver};
 use std::sync::mpsc::channel;
-use std::char;
 
 use rustbox::{RustBox, Event};
 
@@ -78,7 +77,9 @@ impl<'e> Editor<'e> {
     ///
     /// If there is no active Overlay, the key event is sent to the current
     /// Mode, which returns a Command which we dispatch to handle_command.
-    fn handle_key_event(&mut self, key: Option<Key>) {
+    fn handle_key_event(&mut self, event: Event) {
+        let key = Key::from_event(&mut self.rb, event);
+ 
         let key = match key {
             Some(k) => k,
             None => return
@@ -189,15 +190,8 @@ impl<'e> Editor<'e> {
             self.view.maybe_clear_message();
 
             match self.rb.poll_event(true) {
-                Ok(Event::KeyEventRaw(_, key, ch)) => {
-                    let k = match key {
-                        0 => char::from_u32(ch).map(Key::Char),
-                        a => Key::from_special_code(a),
-                    };
-                    self.handle_key_event(k)
-                },
                 Ok(Event::ResizeEvent(width, height)) => self.handle_resize_event(width as usize, height as usize),
-
+                Ok(key_event) => self.handle_key_event(key_event),
                 _ => {}
             }
 

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -45,6 +45,12 @@ impl StandardMode {
         keymap.bind_key(Key::Left, Command::movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Char));
         keymap.bind_key(Key::Right, Command::movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Char));
 
+        keymap.bind_key(Key::CtrlRight, Command::movement(Offset::Forward(1, Mark::Cursor(0)), Kind::Word(Anchor::Start)));
+        keymap.bind_key(Key::CtrlLeft, Command::movement(Offset::Backward(1, Mark::Cursor(0)), Kind::Word(Anchor::Start)));
+    
+        keymap.bind_key(Key::End, Command::movement(Offset::Forward(0, Mark::Cursor(0)), Kind::Line(Anchor::End)));
+        keymap.bind_key(Key::Home, Command::movement(Offset::Backward(0, Mark::Cursor(0)), Kind::Line(Anchor::Start)));
+
         // Editing
         keymap.bind_key(Key::Tab, Command::insert_tab());
         keymap.bind_key(Key::Enter, Command::insert_char('\n'));


### PR DESCRIPTION
This pulls in 4 actions (next/prev word and goto start/end of line) present in emacs mode and binds them to the modern GUI keys.

Binding to Ctrl-Left and Crtl-Right required parsing multibyte terminal control sequences. These aren't available everywhere (e.g. xterm works but a raw tty on Linux does not). I moved a little more event handling logic into the keyboard module, as the function that handles key presses now needs to be able to check if there are additional keyboard events waiting when it receives the start of an escape sequence.