### PR TITLE
Made changes to the README file for nightly build

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ integration with Rust tooling. This could also be applied to other languages too
 Clone the project and run `cargo build --release`.
 
 **NOTE:** Iota needs to be built using the nightly toolchain for now, not stable.<br>
-Run the following commands - `$ rustup install nightly` following which run - `$ rustup default nightly `.<br>
+Run the following commands - `$ rustup install nightly` following which run - `$ rustup override set nightly `.<br>
 [Rustup](https://github.com/rust-lang-nursery/rustup.rs) is very useful for managing
 multiple rust versions.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ integration with Rust tooling. This could also be applied to other languages too
 Clone the project and run `cargo build --release`.
 
 **NOTE:** Iota needs to be built using the nightly toolchain for now, not stable.
+Run the following commands - `$ rustup install nightly` following which run - `$ rustup default nightly `
 [Rustup](https://github.com/rust-lang-nursery/rustup.rs) is very useful for managing
 multiple rust versions.
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ integration with Rust tooling. This could also be applied to other languages too
 
 Clone the project and run `cargo build --release`.
 
-**NOTE:** Iota needs to be built using the nightly toolchain for now, not stable.
-Run the following commands - `$ rustup install nightly` following which run - `$ rustup default nightly `
+**NOTE:** Iota needs to be built using the nightly toolchain for now, not stable.<br>
+Run the following commands - `$ rustup install nightly` following which run - `$ rustup default nightly `.<br>
 [Rustup](https://github.com/rust-lang-nursery/rustup.rs) is very useful for managing
 multiple rust versions.
 


### PR DESCRIPTION
As a beginner it took me time to realize that `$ cargo build --release` is throwing an error because the unstable versions are already available in the nightly build and one needs to install nightly first.