### PR TITLE
Fixes '0' keybinding in vi mode

### DIFF
--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -92,7 +92,7 @@ impl NormalMode {
             Key::Char('0'),
             CommandInfo {
                 command_name: String::from("buffer::move_cursor"),
-                args: Some(BuilderArgs::new().with_kind(Kind::Line(Anchor::End))
+                args: Some(BuilderArgs::new().with_kind(Kind::Line(Anchor::Start))
                                              .with_offset(Offset::Backward(0, Mark::Cursor(0))))
             }
         );


### PR DESCRIPTION
Previously, would do nothing when pressed
Now it correctly jumps to the beginning of a line
Before:
https://asciinema.org/a/FBy1biFw5BlWiWp2XjiWPSJnS
After:
https://asciinema.org/a/IkO76bNeNKVsfWhfboAchjGi5

Previously, also outputted this to the console on keyboard press of `0`
```
mahmoud@megatron:~/Documents/git-repos/iota(master○) » ./target/release/iota src/iota/modes/normal.rs --vi
thread 'main' panicked at 'Unknown command: q', src/iota/editor.rs:129:21
note: Run with `RUST_BACKTRACE=1` for a backtrace.
Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End Unhandled line anchor: End %  
```