### PR TITLE
Simple page up/down implementation

### DIFF
--- a/src/iota/keyboard.rs
+++ b/src/iota/keyboard.rs
@@ -16,6 +16,8 @@ pub enum Key {
     Delete,
     Home,
     End,
+    PageUp,
+    PageDown,
     CtrlLeft,
     CtrlRight,
 
@@ -54,6 +56,8 @@ impl Key {
             65520 => Some(Key::End),
             65521 => Some(Key::Home),
             65522 => Some(Key::Delete),
+            65518 => Some(Key::PageDown),
+            65519 => Some(Key::PageUp),
             _     => None,
         }
     }

--- a/src/iota/modes/emacs.rs
+++ b/src/iota/modes/emacs.rs
@@ -126,6 +126,22 @@ impl EmacsMode {
                                              .with_offset(Offset::Backward(0, Mark::Cursor(0))))
             }
         );
+        keymap.bind_key(
+            Key::PageUp,
+            CommandInfo {
+                command_name: String::from("buffer::move_cursor"),
+                args: Some(BuilderArgs::new().with_kind(Kind::Line(Anchor::Same))
+                                             .with_offset(Offset::Backward(12, Mark::Cursor(0))))
+            }
+        );
+        keymap.bind_key(
+            Key::PageDown,
+            CommandInfo {
+                command_name: String::from("buffer::move_cursor"),
+                args: Some(BuilderArgs::new().with_kind(Kind::Line(Anchor::Same))
+                                             .with_offset(Offset::Forward(12, Mark::Cursor(0))))
+            }
+        );
 
         // Editing
         keymap.bind_key(

--- a/src/iota/modes/normal.rs
+++ b/src/iota/modes/normal.rs
@@ -96,6 +96,22 @@ impl NormalMode {
                                              .with_offset(Offset::Backward(0, Mark::Cursor(0))))
             }
         );
+        keymap.bind_key(
+            Key::Ctrl('b'),
+            CommandInfo {
+                command_name: String::from("buffer::move_cursor"),
+                args: Some(BuilderArgs::new().with_kind(Kind::Line(Anchor::Same))
+                                             .with_offset(Offset::Backward(12, Mark::Cursor(0))))
+            }
+        );
+        keymap.bind_key(
+            Key::Ctrl('f'),
+            CommandInfo {
+                command_name: String::from("buffer::move_cursor"),
+                args: Some(BuilderArgs::new().with_kind(Kind::Line(Anchor::Same))
+                                             .with_offset(Offset::Forward(12, Mark::Cursor(0))))
+            }
+        );
 
         // actions
         keymap.bind_key(

--- a/src/iota/modes/standard.rs
+++ b/src/iota/modes/standard.rs
@@ -118,6 +118,22 @@ impl StandardMode {
                                              .with_offset(Offset::Backward(0, Mark::Cursor(0))))
             }
         );
+        keymap.bind_key(
+            Key::PageUp,
+            CommandInfo {
+                command_name: String::from("buffer::move_cursor"),
+                args: Some(BuilderArgs::new().with_kind(Kind::Line(Anchor::Same))
+                                             .with_offset(Offset::Backward(12, Mark::Cursor(0))))
+            }
+        );
+        keymap.bind_key(
+            Key::PageDown,
+            CommandInfo {
+                command_name: String::from("buffer::move_cursor"),
+                args: Some(BuilderArgs::new().with_kind(Kind::Line(Anchor::Same))
+                                             .with_offset(Offset::Forward(12, Mark::Cursor(0))))
+            }
+        );
 
         // Editing
         keymap.bind_key(


### PR DESCRIPTION
Hi,

This PR adds a simple page up and page down implementation.
At the moment forward or backward 12 lines (a half of 24 lines in standard old consoles).

PD: Maybe a better feature will be moving a Kind::Paragraph? Please let me know.
